### PR TITLE
Initial import from System.IO.Abstractions repo

### DIFF
--- a/System.IO.Abstractions.TestingHelpers.sln
+++ b/System.IO.Abstractions.TestingHelpers.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Abstractions.TestingHelpers", "src\System.IO.Abstractions.TestingHelpers.csproj", "{AB1218E9-6E26-4E3F-B991-D374441C1CAA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Abstractions.TestingHelpers.Tests", "tests\System.IO.Abstractions.TestingHelpers.Tests.csproj", "{DFF7FE3C-70D2-4A14-81A5-2EF2A554830D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AB1218E9-6E26-4E3F-B991-D374441C1CAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB1218E9-6E26-4E3F-B991-D374441C1CAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB1218E9-6E26-4E3F-B991-D374441C1CAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB1218E9-6E26-4E3F-B991-D374441C1CAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFF7FE3C-70D2-4A14-81A5-2EF2A554830D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFF7FE3C-70D2-4A14-81A5-2EF2A554830D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFF7FE3C-70D2-4A14-81A5-2EF2A554830D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFF7FE3C-70D2-4A14-81A5-2EF2A554830D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/IMockFileDataAccessor.cs
+++ b/src/IMockFileDataAccessor.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    /// <summary>
+    /// Provides access to the file system storage.
+    /// </summary>
+    public interface IMockFileDataAccessor
+    {
+        /// <summary>
+        /// Gets a file.
+        /// </summary>
+        /// <param name="path">The path of the file to get.</param>
+        /// <returns>The file. <see langword="null"/> if the file does not exist.</returns>
+        MockFileData GetFile(string path);
+
+        void AddFile(string path, MockFileData mockFile);
+        void AddDirectory(string path);
+
+        void AddFileFromEmbeddedResource(string path, Assembly resourceAssembly, string embeddedResourcePath);
+        void AddFilesFromEmbeddedNamespace(string path, Assembly resourceAssembly, string embeddedRresourcePath);
+
+        void MoveDirectory(string sourcePath, string destPath);
+
+        /// <summary>
+        /// Removes the file.
+        /// </summary>
+        /// <param name="path">The file to remove.</param>
+        /// <remarks>
+        /// The file must not exist.
+        /// </remarks>
+        void RemoveFile(string path);
+
+        /// <summary>
+        /// Determines whether the file exists.
+        /// </summary>
+        /// <param name="path">The file to check. </param>
+        /// <returns><see langword="true"/> if the file exists; otherwise, <see langword="false"/>.</returns>
+        bool FileExists(string path);
+
+        /// <summary>
+        /// Gets all unique paths of all files and directories.
+        /// </summary>
+        IEnumerable<string> AllPaths { get; }
+
+        /// <summary>
+        /// Gets the paths of all files.
+        /// </summary>
+        IEnumerable<string> AllFiles { get; }
+
+        /// <summary>
+        /// Gets the paths of all directories.
+        /// </summary>
+        IEnumerable<string> AllDirectories { get; }
+
+        FileBase File { get; }
+        DirectoryBase Directory { get; }
+        IFileInfoFactory FileInfo {get; }
+        PathBase Path { get; }
+        IDirectoryInfoFactory DirectoryInfo { get; }
+        IDriveInfoFactory DriveInfo { get; }
+
+        PathVerifier PathVerifier { get; }
+
+        IFileSystem FileSystem { get; }
+    }
+}

--- a/src/MockDirectory.cs
+++ b/src/MockDirectory.cs
@@ -1,0 +1,536 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.AccessControl;
+using System.Text.RegularExpressions;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    using XFS = MockUnixSupport;
+
+    [Serializable]
+    public class MockDirectory : DirectoryBase
+    {
+        private readonly FileBase fileBase;
+
+        private readonly IMockFileDataAccessor mockFileDataAccessor;
+
+        private string currentDirectory;
+
+        public MockDirectory(IMockFileDataAccessor mockFileDataAccessor, FileBase fileBase, string currentDirectory) : base(mockFileDataAccessor?.FileSystem)
+        {
+            this.currentDirectory = currentDirectory;
+            this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
+            this.fileBase = fileBase;
+        }
+
+        public override DirectoryInfoBase CreateDirectory(string path)
+        {
+            return CreateDirectoryInternal(path, null);
+        }
+
+#if NET40
+        public override DirectoryInfoBase CreateDirectory(string path, DirectorySecurity directorySecurity)
+        {
+            return CreateDirectoryInternal(path, directorySecurity);
+        }
+#endif
+        private DirectoryInfoBase CreateDirectoryInternal(string path, DirectorySecurity directorySecurity)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            if (path.Length == 0)
+            {
+                throw new ArgumentException(StringResources.Manager.GetString("PATH_CANNOT_BE_THE_EMPTY_STRING_OR_ALL_WHITESPACE"), "path");
+            }
+
+            path = mockFileDataAccessor.Path.GetFullPath(path).TrimSlashes();
+
+            if (!Exists(path))
+            {
+                mockFileDataAccessor.AddDirectory(path);
+            }
+
+            var created = new MockDirectoryInfo(mockFileDataAccessor, path);
+
+            if (directorySecurity != null)
+            {
+                created.SetAccessControl(directorySecurity);
+            }
+
+            return created;
+        }
+
+        public override void Delete(string path)
+        {
+            Delete(path, false);
+        }
+
+        public override void Delete(string path, bool recursive)
+        {
+            path = mockFileDataAccessor.Path.GetFullPath(path).TrimSlashes();
+            var affectedPaths = mockFileDataAccessor
+                .AllPaths
+                .Where(p => p.StartsWith(path, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (!affectedPaths.Any())
+                throw new DirectoryNotFoundException(path + " does not exist or could not be found.");
+
+            if (!recursive &&
+                affectedPaths.Count > 1)
+                throw new IOException("The directory specified by " + path + " is read-only, or recursive is false and " + path + " is not an empty directory.");
+
+            foreach (var affectedPath in affectedPaths)
+                mockFileDataAccessor.RemoveFile(affectedPath);
+        }
+
+        public override bool Exists(string path)
+        {
+            if (path == "/" && XFS.IsUnixPlatform()) 
+            {
+                return true;
+            }
+
+            try
+            {
+                path = path.TrimSlashes();
+                path = mockFileDataAccessor.Path.GetFullPath(path);
+                return mockFileDataAccessor.AllDirectories.Any(p => p.Equals(path, StringComparison.OrdinalIgnoreCase));
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        public override DirectorySecurity GetAccessControl(string path)
+        {           
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+            path = path.TrimSlashes();
+            
+            if (!mockFileDataAccessor.Directory.Exists(path))
+            {
+                throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), path));
+            }
+
+            var directoryData = (MockDirectoryData) mockFileDataAccessor.GetFile(path);
+            return directoryData.AccessControl;
+        }
+
+        public override DirectorySecurity GetAccessControl(string path, AccessControlSections includeSections)
+        {
+            return GetAccessControl(path);
+        }
+
+        public override DateTime GetCreationTime(string path)
+        {
+            return fileBase.GetCreationTime(path);
+        }
+
+        public override DateTime GetCreationTimeUtc(string path)
+        {
+            return fileBase.GetCreationTimeUtc(path);
+        }
+
+        public override string GetCurrentDirectory()
+        {
+            return currentDirectory;
+        }
+
+        public override string[] GetDirectories(string path)
+        {
+            return GetDirectories(path, "*");
+        }
+
+        public override string[] GetDirectories(string path, string searchPattern)
+        {
+            return GetDirectories(path, searchPattern, SearchOption.TopDirectoryOnly);
+        }
+
+        public override string[] GetDirectories(string path, string searchPattern, SearchOption searchOption)
+        {
+            return EnumerateDirectories(path, searchPattern, searchOption).ToArray();
+        }
+
+        public override string GetDirectoryRoot(string path)
+        {
+            return Path.GetPathRoot(path);
+        }
+
+        public override string[] GetFiles(string path)
+        {
+            // Same as what the real framework does
+            return GetFiles(path, "*");
+        }
+
+        public override string[] GetFiles(string path, string searchPattern)
+        {
+            // Same as what the real framework does
+            return GetFiles(path, searchPattern, SearchOption.TopDirectoryOnly);
+        }
+
+        public override string[] GetFiles(string path, string searchPattern, SearchOption searchOption)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+            
+            if (path.Any(c => Path.GetInvalidPathChars().Contains(c)))
+            {
+                throw new ArgumentException("Invalid character(s) in path", nameof(path));
+            }
+
+            if (!Exists(path))
+            {
+                throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), path));
+            }
+
+            return GetFilesInternal(mockFileDataAccessor.AllFiles, path, searchPattern, searchOption);
+        }
+
+        private string[] GetFilesInternal(IEnumerable<string> files, string path, string searchPattern, SearchOption searchOption)
+        {
+            CheckSearchPattern(searchPattern);
+            path = path.TrimSlashes();
+            path = EnsureAbsolutePath(path);
+
+            if (!path.EndsWith(Path.DirectorySeparatorChar.ToString())
+                && !path.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
+            {
+                path += Path.DirectorySeparatorChar;
+            }
+
+            bool isUnix = XFS.IsUnixPlatform();
+
+            string allDirectoriesPattern = isUnix
+                ? @"([^<>:""/|?*]*/)*"
+                : @"([^<>:""/\\|?*]*\\)*";
+
+            string fileNamePattern;
+            string pathPatternSpecial = null;
+            if (searchPattern == "*")
+            {
+                fileNamePattern = isUnix ? @"[^/]*?/?" : @"[^\\]*?\\?";
+            }
+            else
+            {
+                fileNamePattern = Regex.Escape(searchPattern)
+                    .Replace(@"\*", isUnix ? @"[^<>:""/|?*]*?" : @"[^<>:""/\\|?*]*?")
+                    .Replace(@"\?", isUnix ? @"[^<>:""/|?*]?" : @"[^<>:""/\\|?*]?");
+
+                var extension = Path.GetExtension(searchPattern);
+                bool hasExtensionLengthOfThree = extension != null && extension.Length == 4 && !extension.Contains("*") && !extension.Contains("?");
+                if (hasExtensionLengthOfThree)
+                {
+                    var fileNamePatternSpecial = string.Format(CultureInfo.InvariantCulture, "{0}[^.]", fileNamePattern);
+                    pathPatternSpecial = string.Format(
+                        CultureInfo.InvariantCulture,
+                        isUnix ? @"(?i:^{0}{1}{2}(?:/?)$)" : @"(?i:^{0}{1}{2}(?:\\?)$)",
+                        Regex.Escape(path),
+                        searchOption == SearchOption.AllDirectories ? allDirectoriesPattern : string.Empty,
+                        fileNamePatternSpecial);
+                }
+            }
+
+            var pathPattern = string.Format(
+                CultureInfo.InvariantCulture,
+                isUnix ? @"(?i:^{0}{1}{2}(?:/?)$)" : @"(?i:^{0}{1}{2}(?:\\?)$)",
+                Regex.Escape(path),
+                searchOption == SearchOption.AllDirectories ? allDirectoriesPattern : string.Empty,
+                fileNamePattern);
+
+
+            return files
+                .Where(p =>
+                    {
+                        if (Regex.IsMatch(p, pathPattern))
+                        {
+                            return true;
+                        }
+
+                        if (pathPatternSpecial != null && Regex.IsMatch(p, pathPatternSpecial))
+                        {
+                            return true;
+                        }
+
+                        return false;
+                    })
+                .ToArray();
+        }
+
+        public override string[] GetFileSystemEntries(string path)
+        {
+            return GetFileSystemEntries(path, "*");
+        }
+
+        public override string[] GetFileSystemEntries(string path, string searchPattern)
+        {
+            var dirs = GetDirectories(path, searchPattern);
+            var files = GetFiles(path, searchPattern);
+
+            return dirs.Union(files).ToArray();
+        }
+
+        public override DateTime GetLastAccessTime(string path)
+        {
+            return fileBase.GetLastAccessTime(path);
+        }
+
+        public override DateTime GetLastAccessTimeUtc(string path)
+        {
+            return fileBase.GetLastAccessTimeUtc(path);
+        }
+
+        public override DateTime GetLastWriteTime(string path)
+        {
+            return fileBase.GetLastWriteTime(path);
+        }
+
+        public override DateTime GetLastWriteTimeUtc(string path)
+        {
+            return fileBase.GetLastWriteTimeUtc(path);
+        }
+
+#if NET40
+        public override string[] GetLogicalDrives()
+        {
+            return mockFileDataAccessor
+                .AllDirectories
+                .Select(d => new MockDirectoryInfo(mockFileDataAccessor, d).Root.FullName)
+                .Select(r => r.ToLowerInvariant())
+                .Distinct()
+                .ToArray();
+        }
+#endif
+
+        public override DirectoryInfoBase GetParent(string path)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            if (path.Length == 0)
+            {
+                throw new ArgumentException(StringResources.Manager.GetString("PATH_CANNOT_BE_THE_EMPTY_STRING_OR_ALL_WHITESPACE"), "path");
+            }
+
+            if (MockPath.HasIllegalCharacters(path, false))
+            {
+                throw new ArgumentException("Path contains invalid path characters.", "path");
+            }
+
+            var absolutePath = mockFileDataAccessor.Path.GetFullPath(path);
+            var sepAsString = string.Format(CultureInfo.InvariantCulture, "{0}", mockFileDataAccessor.Path.DirectorySeparatorChar);
+
+            var lastIndex = 0;
+            if (absolutePath != sepAsString)
+            {
+                var startIndex = absolutePath.EndsWith(sepAsString, StringComparison.OrdinalIgnoreCase) ? absolutePath.Length - 1 : absolutePath.Length;
+                lastIndex = absolutePath.LastIndexOf(mockFileDataAccessor.Path.DirectorySeparatorChar, startIndex - 1);
+                if (lastIndex < 0)
+                {
+                    return null;
+                }
+            }
+
+            var parentPath = absolutePath.Substring(0, lastIndex);
+            if (string.IsNullOrEmpty(parentPath))
+            {
+                return null;
+            }
+
+            var parent = new MockDirectoryInfo(mockFileDataAccessor, parentPath);
+            return parent;
+        }
+
+        public override void Move(string sourceDirName, string destDirName)
+        {
+            var fullSourcePath = mockFileDataAccessor.Path.GetFullPath(sourceDirName).TrimSlashes();
+            var fullDestPath = mockFileDataAccessor.Path.GetFullPath(destDirName).TrimSlashes();
+
+            if (string.Equals(fullSourcePath, fullDestPath, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new IOException("Source and destination path must be different.");
+            }
+
+            var sourceRoot = mockFileDataAccessor.Path.GetPathRoot(fullSourcePath);
+            var destinationRoot = mockFileDataAccessor.Path.GetPathRoot(fullDestPath);
+            if (!string.Equals(sourceRoot, destinationRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new IOException("Source and destination path must have identical roots. Move will not work across volumes.");
+            }
+
+            if (!mockFileDataAccessor.Directory.Exists(fullSourcePath))
+            {
+                throw new DirectoryNotFoundException($"Could not find a part of the path '{sourceDirName}'.");
+            }
+
+            if (mockFileDataAccessor.Directory.Exists(fullDestPath) || mockFileDataAccessor.File.Exists(fullDestPath))
+            {
+                throw new IOException($"Cannot create '{fullDestPath}' because a file or directory with the same name already exists.");
+            }
+
+            mockFileDataAccessor.MoveDirectory(fullSourcePath, fullDestPath);
+        }
+
+        public override void SetAccessControl(string path, DirectorySecurity directorySecurity)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+            path = path.TrimSlashes();
+
+            if (!mockFileDataAccessor.Directory.Exists(path))
+            {
+                throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), path));
+            }
+
+            var directoryData = (MockDirectoryData)mockFileDataAccessor.GetFile(path);
+            directoryData.AccessControl = directorySecurity;
+        }
+
+        public override void SetCreationTime(string path, DateTime creationTime)
+        {
+            fileBase.SetCreationTime(path, creationTime);
+        }
+
+        public override void SetCreationTimeUtc(string path, DateTime creationTimeUtc)
+        {
+            fileBase.SetCreationTimeUtc(path, creationTimeUtc);
+        }
+
+        public override void SetCurrentDirectory(string path)
+        {
+          currentDirectory = path;
+        }
+
+        public override void SetLastAccessTime(string path, DateTime lastAccessTime)
+        {
+            fileBase.SetLastAccessTime(path, lastAccessTime);
+        }
+
+        public override void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc)
+        {
+            fileBase.SetLastAccessTimeUtc(path, lastAccessTimeUtc);
+        }
+
+        public override void SetLastWriteTime(string path, DateTime lastWriteTime)
+        {
+            fileBase.SetLastWriteTime(path, lastWriteTime);
+        }
+
+        public override void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc)
+        {
+            fileBase.SetLastWriteTimeUtc(path, lastWriteTimeUtc);
+        }
+
+        public override IEnumerable<string> EnumerateDirectories(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            return EnumerateDirectories(path, "*");
+        }
+
+        public override IEnumerable<string> EnumerateDirectories(string path, string searchPattern)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            return EnumerateDirectories(path, searchPattern, SearchOption.TopDirectoryOnly);
+        }
+
+        public override IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            path = path.TrimSlashes();
+            path = mockFileDataAccessor.Path.GetFullPath(path);
+
+            if (!Exists(path))
+            {
+                throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), path));
+            }
+
+            var dirs = GetFilesInternal(mockFileDataAccessor.AllDirectories, path, searchPattern, searchOption);
+            return dirs.Where(p => string.Compare(p, path, StringComparison.OrdinalIgnoreCase) != 0);
+        }
+
+        public override IEnumerable<string> EnumerateFiles(string path)
+        {
+            return GetFiles(path);
+        }
+
+        public override IEnumerable<string> EnumerateFiles(string path, string searchPattern)
+        {
+            return GetFiles(path, searchPattern);
+        }
+
+        public override IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
+        {
+            return GetFiles(path, searchPattern, searchOption);
+        }
+
+        public override IEnumerable<string> EnumerateFileSystemEntries(string path)
+        {
+            var fileSystemEntries = new List<string>(GetFiles(path));
+            fileSystemEntries.AddRange(GetDirectories(path));
+            return fileSystemEntries;
+        }
+
+        public override IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern)
+        {
+            var fileSystemEntries = new List<string>(GetFiles(path, searchPattern));
+            fileSystemEntries.AddRange(GetDirectories(path, searchPattern));
+            return fileSystemEntries;
+        }
+
+        public override IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, SearchOption searchOption)
+        {
+            var fileSystemEntries = new List<string>(GetFiles(path, searchPattern, searchOption));
+            fileSystemEntries.AddRange(GetDirectories(path, searchPattern, searchOption));
+            return fileSystemEntries;
+        }
+
+        private string EnsureAbsolutePath(string path)
+        {
+            return Path.IsPathRooted(path)
+                ? path
+                : Path.Combine(GetCurrentDirectory(), path);
+        }
+
+        static void CheckSearchPattern(string searchPattern)
+        {
+            if (searchPattern == null)
+            {
+                throw new ArgumentNullException(nameof(searchPattern));
+            }
+
+            const string TWO_DOTS = "..";
+            Func<ArgumentException> createException = () => new ArgumentException(@"Search pattern cannot contain "".."" to move up directories and can be contained only internally in file/directory names, as in ""a..b"".", searchPattern);
+
+            if (searchPattern.EndsWith(TWO_DOTS, StringComparison.OrdinalIgnoreCase))
+            {
+                throw createException();
+            }
+
+            int position;
+            if ((position = searchPattern.IndexOf(TWO_DOTS, StringComparison.OrdinalIgnoreCase)) >= 0)
+            {
+                var characterAfterTwoDots = searchPattern[position + 2];
+                if (characterAfterTwoDots == Path.DirectorySeparatorChar || characterAfterTwoDots == Path.AltDirectorySeparatorChar)
+                {
+                    throw createException();
+                }
+            }
+
+            var invalidPathChars = Path.GetInvalidPathChars();
+            if (searchPattern.IndexOfAny(invalidPathChars) > -1)
+            {
+                throw new ArgumentException(StringResources.Manager.GetString("ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION"), "searchPattern");
+            }
+        }
+    }
+}

--- a/src/MockDirectoryData.cs
+++ b/src/MockDirectoryData.cs
@@ -1,0 +1,29 @@
+﻿using System.Security.AccessControl;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    [Serializable]
+    public class MockDirectoryData : MockFileData
+    {
+        [NonSerialized]
+        private DirectorySecurity accessControl;
+        
+        public override bool IsDirectory { get { return true; } }
+
+        public MockDirectoryData() : base(string.Empty)
+        {
+            Attributes = FileAttributes.Directory;
+        }
+
+        public new DirectorySecurity AccessControl
+        {
+            get
+            {
+                // DirectorySecurity's constructor will throw PlatformNotSupportedException on non-Windows platform, so we initialize it in lazy way.
+                // This let's us use this class as long as we don't use AccessControl property.
+                return accessControl ?? (accessControl = new DirectorySecurity());
+            }
+            set { accessControl = value; }
+        }
+    }
+}

--- a/src/MockDirectoryInfo.cs
+++ b/src/MockDirectoryInfo.cs
@@ -1,0 +1,302 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.AccessControl;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    [Serializable]
+    public class MockDirectoryInfo : DirectoryInfoBase
+    {
+        private readonly IMockFileDataAccessor mockFileDataAccessor;
+        private readonly string directoryPath;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MockDirectoryInfo"/> class.
+        /// </summary>
+        /// <param name="mockFileDataAccessor">The mock file data accessor.</param>
+        /// <param name="directoryPath">The directory path.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="mockFileDataAccessor"/> or <paramref name="directoryPath"/> is <see langref="null"/>.</exception>
+        public MockDirectoryInfo(IMockFileDataAccessor mockFileDataAccessor, string directoryPath) : base(mockFileDataAccessor?.FileSystem)
+        {
+            this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
+
+            directoryPath = mockFileDataAccessor.Path.GetFullPath(directoryPath);
+
+            this.directoryPath = directoryPath.TrimSlashes();
+        }
+
+        public override void Delete()
+        {
+            mockFileDataAccessor.Directory.Delete(directoryPath);
+        }
+
+        public override void Refresh()
+        {
+        }
+
+        public override FileAttributes Attributes
+        {
+            get { return GetMockFileDataForRead().Attributes; }
+            set { GetMockFileDataForWrite().Attributes = value; }
+        }
+
+        public override DateTime CreationTime
+        {
+            get { return GetMockFileDataForRead().CreationTime.DateTime; }
+            set { GetMockFileDataForWrite().CreationTime = value; }
+        }
+
+        public override DateTime CreationTimeUtc
+        {
+            get { return GetMockFileDataForRead().CreationTime.UtcDateTime; }
+            set { GetMockFileDataForWrite().CreationTime = value.ToLocalTime(); }
+        }
+
+        public override bool Exists
+        {
+            get { return mockFileDataAccessor.Directory.Exists(FullName); }
+        }
+
+        public override string Extension
+        {
+            get
+            {
+                // System.IO.Path.GetExtension does only string manipulation,
+                // so it's safe to delegate.
+                return Path.GetExtension(directoryPath);
+            }
+        }
+
+        public override string FullName
+        {
+            get
+            {
+                var root = mockFileDataAccessor.Path.GetPathRoot(directoryPath);
+                if (string.Equals(directoryPath, root, StringComparison.OrdinalIgnoreCase))
+                {
+                    // drives have the trailing slash
+                    return directoryPath;
+                }
+
+                // directories do not have a trailing slash
+                return directoryPath.TrimEnd('\\').TrimEnd('/');
+            }
+        }
+
+        public override DateTime LastAccessTime
+        {
+            get { return GetMockFileDataForRead().LastAccessTime.DateTime; }
+            set { GetMockFileDataForWrite().LastAccessTime = value; }
+        }
+
+        public override DateTime LastAccessTimeUtc
+        {
+            get { return GetMockFileDataForRead().LastAccessTime.UtcDateTime; }
+            set { GetMockFileDataForWrite().LastAccessTime = value.ToLocalTime(); }
+        }
+
+        public override DateTime LastWriteTime
+        {
+            get { return GetMockFileDataForRead().LastWriteTime.DateTime; }
+            set { GetMockFileDataForWrite().LastWriteTime = value; }
+        }
+
+        public override DateTime LastWriteTimeUtc
+        {
+            get { return GetMockFileDataForRead().LastWriteTime.UtcDateTime; }
+            set { GetMockFileDataForWrite().LastWriteTime = value.ToLocalTime(); }
+        }
+
+        public override string Name
+        {
+            get { return new MockPath(mockFileDataAccessor).GetFileName(directoryPath.TrimEnd(mockFileDataAccessor.Path.DirectorySeparatorChar)); }
+        }
+
+        public override void Create()
+        {
+            mockFileDataAccessor.Directory.CreateDirectory(FullName);
+        }
+
+#if NET40
+        public override void Create(DirectorySecurity directorySecurity)
+        {
+            mockFileDataAccessor.Directory.CreateDirectory(FullName, directorySecurity);
+        }
+#endif
+
+        public override DirectoryInfoBase CreateSubdirectory(string path)
+        {
+            return mockFileDataAccessor.Directory.CreateDirectory(Path.Combine(FullName, path));
+        }
+
+#if NET40
+        public override DirectoryInfoBase CreateSubdirectory(string path, DirectorySecurity directorySecurity)
+        {
+            return mockFileDataAccessor.Directory.CreateDirectory(Path.Combine(FullName, path), directorySecurity);
+        }
+#endif
+
+        public override void Delete(bool recursive)
+        {
+            mockFileDataAccessor.Directory.Delete(directoryPath, recursive);
+        }
+
+        public override IEnumerable<DirectoryInfoBase> EnumerateDirectories()
+        {
+            return GetDirectories();
+        }
+
+        public override IEnumerable<DirectoryInfoBase> EnumerateDirectories(string searchPattern)
+        {
+            return GetDirectories(searchPattern);
+        }
+
+        public override IEnumerable<DirectoryInfoBase> EnumerateDirectories(string searchPattern, SearchOption searchOption)
+        {
+            return GetDirectories(searchPattern, searchOption);
+        }
+
+        public override IEnumerable<FileInfoBase> EnumerateFiles()
+        {
+            return GetFiles();
+        }
+
+        public override IEnumerable<FileInfoBase> EnumerateFiles(string searchPattern)
+        {
+            return GetFiles(searchPattern);
+        }
+
+        public override IEnumerable<FileInfoBase> EnumerateFiles(string searchPattern, SearchOption searchOption)
+        {
+            return GetFiles(searchPattern, searchOption);
+        }
+
+        public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos()
+        {
+            return GetFileSystemInfos();
+        }
+
+        public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos(string searchPattern)
+        {
+            return GetFileSystemInfos(searchPattern);
+        }
+
+        public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos(string searchPattern, SearchOption searchOption)
+        {
+            return GetFileSystemInfos(searchPattern, searchOption);
+        }
+
+        public override DirectorySecurity GetAccessControl()
+        {
+            return mockFileDataAccessor.Directory.GetAccessControl(directoryPath);
+        }
+
+        public override DirectorySecurity GetAccessControl(AccessControlSections includeSections)
+        {
+            return mockFileDataAccessor.Directory.GetAccessControl(directoryPath, includeSections);
+        }
+
+        public override DirectoryInfoBase[] GetDirectories()
+        {
+            return ConvertStringsToDirectories(mockFileDataAccessor.Directory.GetDirectories(directoryPath));
+        }
+
+        public override DirectoryInfoBase[] GetDirectories(string searchPattern)
+        {
+            return ConvertStringsToDirectories(mockFileDataAccessor.Directory.GetDirectories(directoryPath, searchPattern));
+        }
+
+        public override DirectoryInfoBase[] GetDirectories(string searchPattern, SearchOption searchOption)
+        {
+            return ConvertStringsToDirectories(mockFileDataAccessor.Directory.GetDirectories(directoryPath, searchPattern, searchOption));
+        }
+
+        private DirectoryInfoBase[] ConvertStringsToDirectories(IEnumerable<string> paths)
+        {
+            return paths
+                .Select(path => new MockDirectoryInfo(mockFileDataAccessor, path))
+                .Cast<DirectoryInfoBase>()
+                .ToArray();
+        }
+
+        public override FileInfoBase[] GetFiles()
+        {
+            return ConvertStringsToFiles(mockFileDataAccessor.Directory.GetFiles(FullName));
+        }
+
+        public override FileInfoBase[] GetFiles(string searchPattern)
+        {
+            return ConvertStringsToFiles(mockFileDataAccessor.Directory.GetFiles(FullName, searchPattern));
+        }
+
+        public override FileInfoBase[] GetFiles(string searchPattern, SearchOption searchOption)
+        {
+            return ConvertStringsToFiles(mockFileDataAccessor.Directory.GetFiles(FullName, searchPattern, searchOption));
+        }
+
+        FileInfoBase[] ConvertStringsToFiles(IEnumerable<string> paths)
+        {
+            return paths
+                  .Select(mockFileDataAccessor.FileInfo.FromFileName)
+                  .ToArray();
+        }
+
+        public override FileSystemInfoBase[] GetFileSystemInfos()
+        {
+            return GetFileSystemInfos("*");
+        }
+
+        public override FileSystemInfoBase[] GetFileSystemInfos(string searchPattern)
+        {
+            return GetFileSystemInfos(searchPattern, SearchOption.TopDirectoryOnly);
+        }
+
+        public override FileSystemInfoBase[] GetFileSystemInfos(string searchPattern, SearchOption searchOption)
+        {
+            return GetDirectories(searchPattern, searchOption).OfType<FileSystemInfoBase>().Concat(GetFiles(searchPattern, searchOption)).ToArray();
+        }
+
+        public override void MoveTo(string destDirName)
+        {
+            mockFileDataAccessor.Directory.Move(directoryPath, destDirName);
+        }
+
+        public override void SetAccessControl(DirectorySecurity directorySecurity)
+        {
+            mockFileDataAccessor.Directory.SetAccessControl(directoryPath, directorySecurity);
+        }
+
+        public override DirectoryInfoBase Parent
+        {
+            get
+            {
+                return mockFileDataAccessor.Directory.GetParent(directoryPath);
+            }
+        }
+
+        public override DirectoryInfoBase Root
+        {
+            get
+            {
+                return new MockDirectoryInfo(mockFileDataAccessor, mockFileDataAccessor.Directory.GetDirectoryRoot(FullName));
+            }
+        }
+
+        public override string ToString()
+        {
+            return FullName;
+        }
+
+        private MockFileData GetMockFileDataForRead()
+        {
+            return mockFileDataAccessor.GetFile(directoryPath) ?? MockFileData.NullObject;
+        }
+
+        private MockFileData GetMockFileDataForWrite()
+        {
+            return mockFileDataAccessor.GetFile(directoryPath)
+                ?? throw new FileNotFoundException(StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), directoryPath);
+        }
+    }
+}

--- a/src/MockDirectoryInfoFactory.cs
+++ b/src/MockDirectoryInfoFactory.cs
@@ -1,0 +1,18 @@
+namespace System.IO.Abstractions.TestingHelpers
+{
+    [Serializable]
+    public class MockDirectoryInfoFactory : IDirectoryInfoFactory
+    {
+        readonly IMockFileDataAccessor mockFileSystem;
+
+        public MockDirectoryInfoFactory(IMockFileDataAccessor mockFileSystem)
+        {
+            this.mockFileSystem = mockFileSystem;
+        }
+
+        public DirectoryInfoBase FromDirectoryName(string directoryName)
+        {
+            return new MockDirectoryInfo(mockFileSystem, directoryName);
+        }
+    }
+}

--- a/src/MockDriveInfo.cs
+++ b/src/MockDriveInfo.cs
@@ -1,0 +1,70 @@
+﻿namespace System.IO.Abstractions.TestingHelpers
+{
+    [Serializable]
+    public class MockDriveInfo : DriveInfoBase
+    {
+        private readonly IMockFileDataAccessor mockFileDataAccessor;
+
+        public MockDriveInfo(IMockFileDataAccessor mockFileDataAccessor, string name) : base(mockFileDataAccessor?.FileSystem)
+        {
+            if (mockFileDataAccessor == null)
+            {
+                throw new ArgumentNullException(nameof(mockFileDataAccessor));
+            }
+
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            const string DRIVE_SEPARATOR = @":\";
+            if (name.Length == 1)
+            {
+                name = char.ToUpperInvariant(name[0]) + DRIVE_SEPARATOR;
+            }
+            else if (name.Length == 2 && name[1] == ':')
+            {
+                name = char.ToUpperInvariant(name[0]) + DRIVE_SEPARATOR;
+            }
+            else if (name.Length == 3 && name.EndsWith(DRIVE_SEPARATOR, StringComparison.Ordinal))
+            {
+                name = char.ToUpperInvariant(name[0]) + DRIVE_SEPARATOR;
+            }
+            else
+            {
+                MockPath.CheckInvalidPathChars(name);
+                name = mockFileDataAccessor.Path.GetPathRoot(name);
+
+                if (string.IsNullOrEmpty(name) || name.StartsWith(@"\\", StringComparison.Ordinal))
+                {
+                    throw new ArgumentException(
+                        @"Object must be a root directory (""C:\"") or a drive letter (""C"").");
+                }
+            }
+
+            this.mockFileDataAccessor = mockFileDataAccessor;
+
+            Name = name;
+            IsReady = true;
+        }
+
+        public new long AvailableFreeSpace { get; set; }
+        public new string DriveFormat { get; set; }
+        public new DriveType DriveType { get; set; }
+        public new bool IsReady { get; protected set; }
+        public override string Name { get; protected set; }
+
+        public override DirectoryInfoBase RootDirectory
+        {
+            get
+            {
+                var directory = mockFileDataAccessor.DirectoryInfo.FromDirectoryName(Name);
+                return directory;
+            }
+        }
+
+        public new long TotalFreeSpace { get; protected set; }
+        public new long TotalSize { get; protected set; }
+        public override string VolumeLabel { get; set; }
+    }
+}

--- a/src/MockDriveInfoFactory.cs
+++ b/src/MockDriveInfoFactory.cs
@@ -1,0 +1,96 @@
+﻿using System.Collections.Generic;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    [Serializable]
+    public class MockDriveInfoFactory : IDriveInfoFactory
+    {
+        private readonly IMockFileDataAccessor mockFileSystem;
+
+        public MockDriveInfoFactory(IMockFileDataAccessor mockFileSystem)
+        {
+            this.mockFileSystem = mockFileSystem ?? throw new ArgumentNullException(nameof(mockFileSystem));
+        }
+
+        public DriveInfoBase[] GetDrives()
+        {
+            var driveLetters = new HashSet<string>(new DriveEqualityComparer());
+            foreach (var path in mockFileSystem.AllPaths)
+            {
+                var pathRoot = mockFileSystem.Path.GetPathRoot(path);
+                driveLetters.Add(pathRoot);
+            }
+
+            var result = new List<DriveInfoBase>();
+            foreach (string driveLetter in driveLetters)
+            {
+                try
+                {
+                    var mockDriveInfo = new MockDriveInfo(mockFileSystem, driveLetter);
+                    result.Add(mockDriveInfo);
+                }
+                catch (ArgumentException)
+                {
+                    // invalid drives should be ignored
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        public DriveInfoBase FromDriveName(string driveName)
+        {
+            var drive = mockFileSystem.Path.GetPathRoot(driveName);
+
+            return new MockDriveInfo(mockFileSystem, drive);
+        }
+
+        private string NormalizeDriveName(string driveName)
+        {
+            if (driveName.Length == 3 && driveName.EndsWith(@":\", StringComparison.OrdinalIgnoreCase))
+            {
+                return char.ToUpperInvariant(driveName[0]) + @":\";
+            }
+
+            if (driveName.StartsWith(@"\\", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            return driveName;
+        }
+
+        private class DriveEqualityComparer : IEqualityComparer<string>
+        {
+            public bool Equals(string x, string y)
+            {
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
+                if (ReferenceEquals(x, null))
+                {
+                    return false;
+                }
+
+                if (ReferenceEquals(y, null))
+                {
+                    return false;
+                }
+
+                if (x[1] == ':' && y[1] == ':')
+                {
+                    return char.ToUpperInvariant(x[0]) == char.ToUpperInvariant(y[0]);
+                }
+
+                return false;
+            }
+
+            public int GetHashCode(string obj)
+            {
+                return obj.ToUpperInvariant().GetHashCode();
+            }
+        }
+    }
+}

--- a/src/MockFile.cs
+++ b/src/MockFile.cs
@@ -1,0 +1,1007 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.AccessControl;
+using System.Text;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    [Serializable]
+    public class MockFile : FileBase
+    {
+        private readonly IMockFileDataAccessor mockFileDataAccessor;
+        private readonly MockPath mockPath;
+
+        public MockFile(IMockFileDataAccessor mockFileDataAccessor) : base(mockFileDataAccessor?.FileSystem)
+        {
+            this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
+            mockPath = new MockPath(mockFileDataAccessor);
+        }
+
+        public override void AppendAllLines(string path, IEnumerable<string> contents)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+            VerifyValueIsNotNull(contents, "contents");
+
+            AppendAllLines(path, contents, MockFileData.DefaultEncoding);
+        }
+
+        public override void AppendAllLines(string path, IEnumerable<string> contents, Encoding encoding)
+        {
+            if (encoding == null)
+            {
+                throw new ArgumentNullException(nameof(encoding));
+            }
+
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            var concatContents = contents.Aggregate("", (a, b) => a + b + Environment.NewLine);
+            AppendAllText(path, concatContents, encoding);
+        }
+
+        public override void AppendAllText(string path, string contents)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            AppendAllText(path, contents, MockFileData.DefaultEncoding);
+        }
+
+        public override void AppendAllText(string path, string contents, Encoding encoding)
+        {
+            if (encoding == null)
+            {
+                throw new ArgumentNullException(nameof(encoding));
+            }
+
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            if (!mockFileDataAccessor.FileExists(path))
+            {
+                var dir = mockFileDataAccessor.Path.GetDirectoryName(path);
+                if (!mockFileDataAccessor.Directory.Exists(dir))
+                {
+                    throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), path));
+                }
+
+                mockFileDataAccessor.AddFile(path, new MockFileData(contents, encoding));
+            }
+            else
+            {
+                var file = mockFileDataAccessor.GetFile(path);
+                var bytesToAppend = encoding.GetBytes(contents);
+                file.Contents = file.Contents.Concat(bytesToAppend).ToArray();
+            }
+        }
+
+        public override StreamWriter AppendText(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            if (mockFileDataAccessor.FileExists(path))
+            {
+                StreamWriter sw = new StreamWriter(OpenWrite(path));
+                sw.BaseStream.Seek(0, SeekOrigin.End); //push the stream pointer at the end for append.
+                return sw;
+            }
+
+            return new StreamWriter(Create(path));
+        }
+
+        public override void Copy(string sourceFileName, string destFileName)
+        {
+            Copy(sourceFileName, destFileName, false);
+        }
+
+        public override void Copy(string sourceFileName, string destFileName, bool overwrite)
+        {
+            if (sourceFileName == null)
+            {
+                throw new ArgumentNullException(nameof(sourceFileName), StringResources.Manager.GetString("FILENAME_CANNOT_BE_NULL"));
+            }
+
+            if (destFileName == null)
+            {
+                throw new ArgumentNullException(nameof(destFileName), StringResources.Manager.GetString("FILENAME_CANNOT_BE_NULL"));
+            }
+
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(sourceFileName, "sourceFileName");
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(destFileName, "destFileName");
+
+            if (!Exists(sourceFileName))
+            {
+                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), sourceFileName));
+            }
+
+            var directoryNameOfDestination = mockPath.GetDirectoryName(destFileName);
+            if (!mockFileDataAccessor.Directory.Exists(directoryNameOfDestination))
+            {
+                throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), destFileName));
+            }
+
+            var fileExists = mockFileDataAccessor.FileExists(destFileName);
+            if (fileExists)
+            {
+                if (!overwrite)
+                {
+                    throw new IOException(string.Format(CultureInfo.InvariantCulture, "The file {0} already exists.", destFileName));
+                }
+
+                mockFileDataAccessor.RemoveFile(destFileName);
+            }
+
+            var sourceFileData = mockFileDataAccessor.GetFile(sourceFileName);
+            mockFileDataAccessor.AddFile(destFileName, new MockFileData(sourceFileData));
+        }
+
+        public override Stream Create(string path) =>
+            Create(path, 4096);
+
+        public override Stream Create(string path, int bufferSize) =>
+            Create(path, bufferSize, FileOptions.None);
+
+        public override Stream Create(string path, int bufferSize, FileOptions options) =>
+            CreateInternal(path, bufferSize, options, null);
+
+#if NET40
+        public override Stream Create(string path, int bufferSize, FileOptions options, FileSecurity fileSecurity) =>
+            CreateInternal(path, bufferSize, options, fileSecurity);
+#endif
+
+        private Stream CreateInternal(string path, int bufferSize, FileOptions options, FileSecurity fileSecurity)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path), "Path cannot be null.");
+            }
+
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, nameof(path));
+            var directoryPath = mockPath.GetDirectoryName(path);
+
+            if (!mockFileDataAccessor.Directory.Exists(directoryPath))
+            {
+                throw new DirectoryNotFoundException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"),
+                        path));
+            }
+
+            var mockFileData = new MockFileData(new byte[0])
+            {
+                AccessControl = fileSecurity
+            };
+            mockFileDataAccessor.AddFile(path, mockFileData);
+            return OpenWriteInternal(path, options);
+        }
+
+        public override StreamWriter CreateText(string path)
+        {
+            return new StreamWriter(Create(path));
+        }
+
+#if NET40
+        public override void Decrypt(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            new MockFileInfo(mockFileDataAccessor, path).Decrypt();
+        }
+#endif
+        public override void Delete(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            // We mimic exact behavior of the standard File.Delete() method
+            // which throws exception only if the folder does not exist,
+            // but silently returns if deleting a non-existing file in an existing folder.
+            VerifyDirectoryExists(path);
+
+            mockFileDataAccessor.RemoveFile(path);
+        }
+
+#if NET40
+        public override void Encrypt(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            new MockFileInfo(mockFileDataAccessor, path).Encrypt();
+        }
+#endif
+
+        public override bool Exists(string path)
+        {
+            if (path == null)
+            {
+                return false;
+            }
+
+            var file = mockFileDataAccessor.GetFile(path);
+            return file != null && !file.IsDirectory;
+        }
+
+        public override FileSecurity GetAccessControl(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            if (!mockFileDataAccessor.FileExists(path))
+            {
+                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), path));
+            }
+
+            var fileData = mockFileDataAccessor.GetFile(path);
+            return fileData.AccessControl;
+        }
+
+        public override FileSecurity GetAccessControl(string path, AccessControlSections includeSections)
+        {
+            return GetAccessControl(path);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="FileAttributes"/> of the file on the path.
+        /// </summary>
+        /// <param name="path">The path to the file.</param>
+        /// <returns>The <see cref="FileAttributes"/> of the file on the path.</returns>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is empty, contains only white spaces, or contains invalid characters.</exception>
+        /// <exception cref="PathTooLongException">The specified path, file name, or both exceed the system-defined maximum length. For example, on Windows-based platforms, paths must be less than 248 characters, and file names must be less than 260 characters.</exception>
+        /// <exception cref="NotSupportedException"><paramref name="path"/> is in an invalid format.</exception>
+        /// <exception cref="FileNotFoundException"><paramref name="path"/> represents a file and is invalid, such as being on an unmapped drive, or the file cannot be found.</exception>
+        /// <exception cref="DirectoryNotFoundException"><paramref name="path"/> represents a directory and is invalid, such as being on an unmapped drive, or the directory cannot be found.</exception>
+        /// <exception cref="IOException">This file is being used by another process.</exception>
+        /// <exception cref="UnauthorizedAccessException">The caller does not have the required permission.</exception>
+        public override FileAttributes GetAttributes(string path)
+        {
+            if (path != null && path.Length == 0)
+            {
+                throw new ArgumentException(StringResources.Manager.GetString("THE_PATH_IS_NOT_OF_A_LEGAL_FORM"), "path");
+            }
+
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            var possibleFileData = mockFileDataAccessor.GetFile(path);
+            FileAttributes result;
+            if (possibleFileData != null)
+            {
+                result = possibleFileData.Attributes;
+            }
+            else
+            {
+                var directoryInfo = mockFileDataAccessor.DirectoryInfo.FromDirectoryName(path);
+                if (directoryInfo.Exists)
+                {
+                    result = directoryInfo.Attributes;
+                }
+                else
+                {
+                    VerifyDirectoryExists(path);
+
+                    throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "Could not find file '{0}'.", path));
+                }
+            }
+
+            return result;
+        }
+
+        public override DateTime GetCreationTime(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            return GetTimeFromFile(path, data => data.CreationTime.LocalDateTime, () => MockFileData.DefaultDateTimeOffset.LocalDateTime);
+        }
+
+        public override DateTime GetCreationTimeUtc(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            return GetTimeFromFile(path, data => data.CreationTime.UtcDateTime, () => MockFileData.DefaultDateTimeOffset.UtcDateTime);
+        }
+
+        public override DateTime GetLastAccessTime(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            return GetTimeFromFile(path, data => data.LastAccessTime.LocalDateTime, () => MockFileData.DefaultDateTimeOffset.LocalDateTime);
+        }
+
+        public override DateTime GetLastAccessTimeUtc(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            return GetTimeFromFile(path, data => data.LastAccessTime.UtcDateTime, () => MockFileData.DefaultDateTimeOffset.UtcDateTime);
+        }
+
+        public override DateTime GetLastWriteTime(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            return GetTimeFromFile(path, data => data.LastWriteTime.LocalDateTime, () => MockFileData.DefaultDateTimeOffset.LocalDateTime);
+        }
+
+        public override DateTime GetLastWriteTimeUtc(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            return GetTimeFromFile(path, data => data.LastWriteTime.UtcDateTime, () => MockFileData.DefaultDateTimeOffset.UtcDateTime);
+        }
+
+        private DateTime GetTimeFromFile(string path, Func<MockFileData, DateTime> existingFileFunction, Func<DateTime> nonExistingFileFunction)
+        {
+            DateTime result;
+            MockFileData file = mockFileDataAccessor.GetFile(path);
+            if (file != null)
+            {
+                result = existingFileFunction(file);
+            }
+            else
+            {
+                result = nonExistingFileFunction();
+            }
+
+            return result;
+        }
+
+        public override void Move(string sourceFileName, string destFileName)
+        {
+            if (sourceFileName == null)
+            {
+                throw new ArgumentNullException(nameof(sourceFileName), StringResources.Manager.GetString("FILENAME_CANNOT_BE_NULL"));
+            }
+
+            if (destFileName == null)
+            {
+                throw new ArgumentNullException(nameof(destFileName), StringResources.Manager.GetString("FILENAME_CANNOT_BE_NULL"));
+            }
+
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(sourceFileName, "sourceFileName");
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(destFileName, "destFileName");
+
+            if (mockFileDataAccessor.GetFile(destFileName) != null)
+            {
+                if (destFileName.Equals(sourceFileName))
+                {
+                    return;
+                }
+                else
+                {
+                    throw new IOException("A file can not be created if it already exists.");
+                }
+            }
+
+
+            var sourceFile = mockFileDataAccessor.GetFile(sourceFileName);
+
+            if (sourceFile == null)
+                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "The file \"{0}\" could not be found.", sourceFileName), sourceFileName);
+
+            VerifyDirectoryExists(destFileName);
+
+            mockFileDataAccessor.AddFile(destFileName, new MockFileData(sourceFile.Contents));
+            mockFileDataAccessor.RemoveFile(sourceFileName);
+        }
+
+        public override Stream Open(string path, FileMode mode)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            return Open(path, mode, (mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite), FileShare.None);
+        }
+
+        public override Stream Open(string path, FileMode mode, FileAccess access)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            return Open(path, mode, access, FileShare.None);
+        }
+
+        public override Stream Open(string path, FileMode mode, FileAccess access, FileShare share) =>
+            OpenInternal(path, mode, access, share, FileOptions.None);
+
+        private Stream OpenInternal(
+            string path,
+            FileMode mode,
+            FileAccess access,
+            FileShare share,
+            FileOptions options)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            bool exists = mockFileDataAccessor.FileExists(path);
+
+            if (mode == FileMode.CreateNew && exists)
+                throw new IOException(string.Format(CultureInfo.InvariantCulture, "The file '{0}' already exists.", path));
+
+            if ((mode == FileMode.Open || mode == FileMode.Truncate) && !exists)
+                throw new FileNotFoundException(path);
+
+            if (!exists || mode == FileMode.CreateNew)
+                return Create(path);
+
+            if (mode == FileMode.Create || mode == FileMode.Truncate)
+            {
+                Delete(path);
+                return Create(path);
+            }
+
+            var length = mockFileDataAccessor.GetFile(path).Contents.Length;
+
+            MockFileStream.StreamType streamType = MockFileStream.StreamType.WRITE;
+            if (access == FileAccess.Read)
+                streamType = MockFileStream.StreamType.READ;
+            else if (mode == FileMode.Append)
+                streamType = MockFileStream.StreamType.APPEND;
+
+            return new MockFileStream(mockFileDataAccessor, path, streamType, options);
+        }
+
+        public override Stream OpenRead(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            return Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        }
+
+        public override StreamReader OpenText(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            return new StreamReader(
+                OpenRead(path));
+        }
+
+        public override Stream OpenWrite(string path) => OpenWriteInternal(path, FileOptions.None);
+
+        private Stream OpenWriteInternal(string path, FileOptions options)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+            return OpenInternal(path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None, options);
+        }
+
+        public override byte[] ReadAllBytes(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            if (!mockFileDataAccessor.FileExists(path))
+            {
+                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), path));
+            }
+
+            return mockFileDataAccessor.GetFile(path).Contents;
+        }
+
+        public override string[] ReadAllLines(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            if (!mockFileDataAccessor.FileExists(path))
+            {
+                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), path));
+            }
+
+            return mockFileDataAccessor
+                .GetFile(path)
+                .TextContents
+                .SplitLines();
+        }
+
+        public override string[] ReadAllLines(string path, Encoding encoding)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            if (encoding == null)
+            {
+                throw new ArgumentNullException(nameof(encoding));
+            }
+
+            if (!mockFileDataAccessor.FileExists(path))
+            {
+                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "Can't find {0}", path));
+            }
+
+            return encoding
+                .GetString(mockFileDataAccessor.GetFile(path).Contents)
+                .SplitLines();
+        }
+
+        public override string ReadAllText(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            if (!mockFileDataAccessor.FileExists(path))
+            {
+                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "Can't find {0}", path));
+            }
+
+            return ReadAllText(path, MockFileData.DefaultEncoding);
+        }
+
+        public override string ReadAllText(string path, Encoding encoding)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            if (encoding == null)
+            {
+                throw new ArgumentNullException(nameof(encoding));
+            }
+
+            return ReadAllTextInternal(path, encoding);
+        }
+
+        public override IEnumerable<string> ReadLines(string path)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            return ReadAllLines(path);
+        }
+
+        public override IEnumerable<string> ReadLines(string path, Encoding encoding)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+            VerifyValueIsNotNull(encoding, "encoding");
+
+            return ReadAllLines(path, encoding);
+        }
+
+#if NET40
+        public override void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName)
+        {
+            Replace(sourceFileName, destinationFileName, destinationBackupFileName, false);
+        }
+
+        public override void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
+        {
+            if (sourceFileName == null)
+            {
+                throw new ArgumentNullException(nameof(sourceFileName));
+            }
+
+            if (destinationFileName == null)
+            {
+                throw new ArgumentNullException(nameof(destinationFileName));
+            }
+
+            if (!mockFileDataAccessor.FileExists(sourceFileName))
+            {
+                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), sourceFileName));
+            }
+
+            if (!mockFileDataAccessor.FileExists(destinationFileName))
+            {
+                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), destinationFileName));
+            }
+
+            var mockFile = new MockFile(mockFileDataAccessor);
+
+            if (destinationBackupFileName != null)
+            {
+                mockFile.Copy(destinationFileName, destinationBackupFileName, true);
+            }
+
+            mockFile.Delete(destinationFileName);
+            mockFile.Move(sourceFileName, destinationFileName);
+        }
+#endif
+
+        public override void SetAccessControl(string path, FileSecurity fileSecurity)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            if (!mockFileDataAccessor.FileExists(path))
+            {
+                throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "Can't find {0}", path), path);
+            }
+
+            var fileData = mockFileDataAccessor.GetFile(path);
+            fileData.AccessControl = fileSecurity;
+        }
+
+        public override void SetAttributes(string path, FileAttributes fileAttributes)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            var possibleFileData = mockFileDataAccessor.GetFile(path);
+            if (possibleFileData == null)
+            {
+                var directoryInfo = mockFileDataAccessor.DirectoryInfo.FromDirectoryName(path);
+                if (directoryInfo.Exists)
+                {
+                    directoryInfo.Attributes = fileAttributes;
+                }
+                else
+                {
+                    throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_FILE_EXCEPTION"), path), path);
+                }
+            }
+            else
+            {
+                possibleFileData.Attributes = fileAttributes;
+            }
+        }
+
+        public override void SetCreationTime(string path, DateTime creationTime)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            mockFileDataAccessor.GetFile(path).CreationTime = new DateTimeOffset(creationTime);
+        }
+
+        public override void SetCreationTimeUtc(string path, DateTime creationTimeUtc)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            mockFileDataAccessor.GetFile(path).CreationTime = new DateTimeOffset(creationTimeUtc, TimeSpan.Zero);
+        }
+
+        public override void SetLastAccessTime(string path, DateTime lastAccessTime)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            mockFileDataAccessor.GetFile(path).LastAccessTime = new DateTimeOffset(lastAccessTime);
+        }
+
+        public override void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            mockFileDataAccessor.GetFile(path).LastAccessTime = new DateTimeOffset(lastAccessTimeUtc, TimeSpan.Zero);
+        }
+
+        public override void SetLastWriteTime(string path, DateTime lastWriteTime)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            mockFileDataAccessor.GetFile(path).LastWriteTime = new DateTimeOffset(lastWriteTime);
+        }
+
+        public override void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+
+            mockFileDataAccessor.GetFile(path).LastWriteTime = new DateTimeOffset(lastWriteTimeUtc, TimeSpan.Zero);
+        }
+
+        /// <summary>
+        /// Creates a new file, writes the specified byte array to the file, and then closes the file.
+        /// If the target file already exists, it is overwritten.
+        /// </summary>
+        /// <param name="path">The file to write to.</param>
+        /// <param name="bytes">The bytes to write to the file. </param>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is a zero-length string, contains only white space, or contains one or more invalid characters as defined by <see cref="Path.GetInvalidPathChars"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/> or contents is empty.</exception>
+        /// <exception cref="PathTooLongException">
+        /// The specified path, file name, or both exceed the system-defined maximum length.
+        /// For example, on Windows-based platforms, paths must be less than 248 characters, and file names must be less than 260 characters.
+        /// </exception>
+        /// <exception cref="DirectoryNotFoundException">The specified path is invalid (for example, it is on an unmapped drive).</exception>
+        /// <exception cref="IOException">An I/O error occurred while opening the file.</exception>
+        /// <exception cref="UnauthorizedAccessException">
+        /// path specified a file that is read-only.
+        /// -or-
+        /// This operation is not supported on the current platform.
+        /// -or-
+        /// path specified a directory.
+        /// -or-
+        /// The caller does not have the required permission.
+        /// </exception>
+        /// <exception cref="FileNotFoundException">The file specified in <paramref name="path"/> was not found.</exception>
+        /// <exception cref="NotSupportedException"><paramref name="path"/> is in an invalid format.</exception>
+        /// <exception cref="System.Security.SecurityException">The caller does not have the required permission.</exception>
+        /// <remarks>
+        /// Given a byte array and a file path, this method opens the specified file, writes the contents of the byte array to the file, and then closes the file.
+        /// </remarks>
+        public override void WriteAllBytes(string path, byte[] bytes)
+        {
+            VerifyValueIsNotNull(bytes, "bytes");
+
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+            VerifyDirectoryExists(path);
+
+            mockFileDataAccessor.AddFile(path, new MockFileData(bytes));
+        }
+
+       /// <summary>
+        /// Creates a new file, writes a collection of strings to the file, and then closes the file.
+        /// </summary>
+        /// <param name="path">The file to write to.</param>
+        /// <param name="contents">The lines to write to the file.</param>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is a zero-length string, contains only white space, or contains one or more invalid characters as defined by <see cref="Path.GetInvalidPathChars"/>.</exception>
+        /// <exception cref="ArgumentNullException">Either <paramref name="path"/> or <paramref name="contents"/> is <see langword="null"/>.</exception>
+        /// <exception cref="DirectoryNotFoundException">The specified path is invalid (for example, it is on an unmapped drive).</exception>
+        /// <exception cref="FileNotFoundException">The file specified in <paramref name="path"/> was not found.</exception>
+        /// <exception cref="IOException">An I/O error occurred while opening the file.</exception>
+        /// <exception cref="PathTooLongException">
+        /// The specified path, file name, or both exceed the system-defined maximum length.
+        /// For example, on Windows-based platforms, paths must be less than 248 characters, and file names must be less than 260 characters.
+        /// </exception>
+        /// <exception cref="NotSupportedException"><paramref name="path"/> is in an invalid format.</exception>
+        /// <exception cref="System.Security.SecurityException">The caller does not have the required permission.</exception>
+        /// <exception cref="UnauthorizedAccessException">
+        /// <paramref name="path"/> specified a file that is read-only.
+        /// -or-
+        /// This operation is not supported on the current platform.
+        /// -or-
+        /// <paramref name="path"/> specified a directory.
+        /// -or-
+        /// The caller does not have the required permission.
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        ///     If the target file already exists, it is overwritten.
+        /// </para>
+        /// <para>
+        ///     You can use this method to create the contents for a collection class that takes an <see cref="IEnumerable{T}"/> in its constructor, such as a <see cref="List{T}"/>, <see cref="HashSet{T}"/>, or a <see cref="SortedSet{T}"/> class.
+        /// </para>
+        /// </remarks>
+        public override void WriteAllLines(string path, IEnumerable<string> contents)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+            VerifyValueIsNotNull(contents, "contents");
+
+            WriteAllLines(path, contents, MockFileData.DefaultEncoding);
+        }
+
+        /// <summary>
+        /// Creates a new file by using the specified encoding, writes a collection of strings to the file, and then closes the file.
+        /// </summary>
+        /// <param name="path">The file to write to.</param>
+        /// <param name="contents">The lines to write to the file.</param>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is a zero-length string, contains only white space, or contains one or more invalid characters as defined by <see cref="Path.GetInvalidPathChars"/>.</exception>
+        /// <exception cref="ArgumentNullException">Either <paramref name="path"/>, <paramref name="contents"/>, or <paramref name="encoding"/> is <see langword="null"/>.</exception>
+        /// <exception cref="DirectoryNotFoundException">The specified path is invalid (for example, it is on an unmapped drive).</exception>
+        /// <exception cref="FileNotFoundException">The file specified in <paramref name="path"/> was not found.</exception>
+        /// <exception cref="IOException">An I/O error occurred while opening the file.</exception>
+        /// <exception cref="PathTooLongException">
+        /// The specified path, file name, or both exceed the system-defined maximum length.
+        /// For example, on Windows-based platforms, paths must be less than 248 characters, and file names must be less than 260 characters.
+        /// </exception>
+        /// <exception cref="NotSupportedException"><paramref name="path"/> is in an invalid format.</exception>
+        /// <exception cref="System.Security.SecurityException">The caller does not have the required permission.</exception>
+        /// <exception cref="UnauthorizedAccessException">
+        /// <paramref name="path"/> specified a file that is read-only.
+        /// -or-
+        /// This operation is not supported on the current platform.
+        /// -or-
+        /// <paramref name="path"/> specified a directory.
+        /// -or-
+        /// The caller does not have the required permission.
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        ///     If the target file already exists, it is overwritten.
+        /// </para>
+        /// <para>
+        ///     You can use this method to create a file that contains the following:
+        /// <list type="bullet">
+        /// <item>
+        /// <description>The results of a LINQ to Objects query on the lines of a file, as obtained by using the ReadLines method.</description>
+        /// </item>
+        /// <item>
+        /// <description>The contents of a collection that implements an <see cref="IEnumerable{T}"/> of strings.</description>
+        /// </item>
+        /// </list>
+        /// </para>
+        /// </remarks>
+        public override void WriteAllLines(string path, IEnumerable<string> contents, Encoding encoding)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+            VerifyValueIsNotNull(contents, "contents");
+            VerifyValueIsNotNull(encoding, "encoding");
+
+            var sb = new StringBuilder();
+            foreach (var line in contents)
+            {
+                sb.AppendLine(line);
+            }
+
+            WriteAllText(path, sb.ToString(), encoding);
+        }
+
+        /// <summary>
+        /// Creates a new file, writes the specified string array to the file by using the specified encoding, and then closes the file.
+        /// </summary>
+        /// <param name="path">The file to write to.</param>
+        /// <param name="contents">The string array to write to the file.</param>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is a zero-length string, contains only white space, or contains one or more invalid characters as defined by <see cref="Path.GetInvalidPathChars"/>.</exception>
+        /// <exception cref="ArgumentNullException">Either <paramref name="path"/> or <paramref name="contents"/> is <see langword="null"/>.</exception>
+        /// <exception cref="PathTooLongException">
+        /// The specified path, file name, or both exceed the system-defined maximum length.
+        /// For example, on Windows-based platforms, paths must be less than 248 characters, and file names must be less than 260 characters.
+        /// </exception>
+        /// <exception cref="DirectoryNotFoundException">The specified path is invalid (for example, it is on an unmapped drive).</exception>
+        /// <exception cref="IOException">An I/O error occurred while opening the file.</exception>
+        /// <exception cref="UnauthorizedAccessException">
+        /// <paramref name="path"/> specified a file that is read-only.
+        /// -or-
+        /// This operation is not supported on the current platform.
+        /// -or-
+        /// <paramref name="path"/> specified a directory.
+        /// -or-
+        /// The caller does not have the required permission.
+        /// </exception>
+        /// <exception cref="FileNotFoundException">The file specified in <paramref name="path"/> was not found.</exception>
+        /// <exception cref="NotSupportedException"><paramref name="path"/> is in an invalid format.</exception>
+        /// <exception cref="System.Security.SecurityException">The caller does not have the required permission.</exception>
+        /// <remarks>
+        /// <para>
+        ///     If the target file already exists, it is overwritten.
+        /// </para>
+        /// <para>
+        ///     The default behavior of the WriteAllLines method is to write out data using UTF-8 encoding without a byte order mark (BOM). If it is necessary to include a UTF-8 identifier, such as a byte order mark, at the beginning of a file, use the <see cref="FileBase.WriteAllLines(string,string[],System.Text.Encoding)"/> method overload with <see cref="UTF8Encoding"/> encoding.
+        /// </para>
+        /// <para>
+        ///     Given a string array and a file path, this method opens the specified file, writes the string array to the file using the specified encoding,
+        ///     and then closes the file.
+        /// </para>
+        /// </remarks>
+        public override void WriteAllLines(string path, string[] contents)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+            VerifyValueIsNotNull(contents, "contents");
+
+            WriteAllLines(path, contents, MockFileData.DefaultEncoding);
+        }
+
+        /// <summary>
+        /// Creates a new file, writes the specified string array to the file by using the specified encoding, and then closes the file.
+        /// </summary>
+        /// <param name="path">The file to write to.</param>
+        /// <param name="contents">The string array to write to the file.</param>
+        /// <param name="encoding">An <see cref="Encoding"/> object that represents the character encoding applied to the string array.</param>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is a zero-length string, contains only white space, or contains one or more invalid characters as defined by <see cref="Path.GetInvalidPathChars"/>.</exception>
+        /// <exception cref="ArgumentNullException">Either <paramref name="path"/> or <paramref name="contents"/> is <see langword="null"/>.</exception>
+        /// <exception cref="PathTooLongException">
+        /// The specified path, file name, or both exceed the system-defined maximum length.
+        /// For example, on Windows-based platforms, paths must be less than 248 characters, and file names must be less than 260 characters.
+        /// </exception>
+        /// <exception cref="DirectoryNotFoundException">The specified path is invalid (for example, it is on an unmapped drive).</exception>
+        /// <exception cref="IOException">An I/O error occurred while opening the file.</exception>
+        /// <exception cref="UnauthorizedAccessException">
+        /// <paramref name="path"/> specified a file that is read-only.
+        /// -or-
+        /// This operation is not supported on the current platform.
+        /// -or-
+        /// <paramref name="path"/> specified a directory.
+        /// -or-
+        /// The caller does not have the required permission.
+        /// </exception>
+        /// <exception cref="FileNotFoundException">The file specified in <paramref name="path"/> was not found.</exception>
+        /// <exception cref="NotSupportedException"><paramref name="path"/> is in an invalid format.</exception>
+        /// <exception cref="System.Security.SecurityException">The caller does not have the required permission.</exception>
+        /// <remarks>
+        /// <para>
+        ///     If the target file already exists, it is overwritten.
+        /// </para>
+        /// <para>
+        ///     Given a string array and a file path, this method opens the specified file, writes the string array to the file using the specified encoding,
+        ///     and then closes the file.
+        /// </para>
+        /// </remarks>
+        public override void WriteAllLines(string path, string[] contents, Encoding encoding)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+            VerifyValueIsNotNull(contents, "contents");
+            VerifyValueIsNotNull(encoding, "encoding");
+
+            WriteAllLines(path, new List<string>(contents), encoding);
+        }
+
+        /// <summary>
+        /// Creates a new file, writes the specified string to the file using the specified encoding, and then closes the file. If the target file already exists, it is overwritten.
+        /// </summary>
+        /// <param name="path">The file to write to. </param>
+        /// <param name="contents">The string to write to the file. </param>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is a zero-length string, contains only white space, or contains one or more invalid characters as defined by <see cref="Path.GetInvalidPathChars"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/> or contents is empty.</exception>
+        /// <exception cref="PathTooLongException">
+        /// The specified path, file name, or both exceed the system-defined maximum length.
+        /// For example, on Windows-based platforms, paths must be less than 248 characters, and file names must be less than 260 characters.
+        /// </exception>
+        /// <exception cref="DirectoryNotFoundException">The specified path is invalid (for example, it is on an unmapped drive).</exception>
+        /// <exception cref="IOException">An I/O error occurred while opening the file.</exception>
+        /// <exception cref="UnauthorizedAccessException">
+        /// path specified a file that is read-only.
+        /// -or-
+        /// This operation is not supported on the current platform.
+        /// -or-
+        /// path specified a directory.
+        /// -or-
+        /// The caller does not have the required permission.
+        /// </exception>
+        /// <exception cref="FileNotFoundException">The file specified in <paramref name="path"/> was not found.</exception>
+        /// <exception cref="NotSupportedException"><paramref name="path"/> is in an invalid format.</exception>
+        /// <exception cref="System.Security.SecurityException">The caller does not have the required permission.</exception>
+        /// <remarks>
+        /// This method uses UTF-8 encoding without a Byte-Order Mark (BOM), so using the <see cref="M:Encoding.GetPreamble"/> method will return an empty byte array.
+        /// If it is necessary to include a UTF-8 identifier, such as a byte order mark, at the beginning of a file, use the <see cref="FileBase.WriteAllText(string,string,System.Text.Encoding)"/> method overload with <see cref="UTF8Encoding"/> encoding.
+        /// <para>
+        /// Given a string and a file path, this method opens the specified file, writes the string to the file, and then closes the file.
+        /// </para>
+        /// </remarks>
+        public override void WriteAllText(string path, string contents)
+        {
+            WriteAllText(path, contents, MockFileData.DefaultEncoding);
+        }
+
+        /// <summary>
+        /// Creates a new file, writes the specified string to the file using the specified encoding, and then closes the file. If the target file already exists, it is overwritten.
+        /// </summary>
+        /// <param name="path">The file to write to. </param>
+        /// <param name="contents">The string to write to the file. </param>
+        /// <param name="encoding">The encoding to apply to the string.</param>
+        /// <exception cref="ArgumentException"><paramref name="path"/> is a zero-length string, contains only white space, or contains one or more invalid characters as defined by <see cref="Path.GetInvalidPathChars"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/> or contents is empty.</exception>
+        /// <exception cref="PathTooLongException">
+        /// The specified path, file name, or both exceed the system-defined maximum length.
+        /// For example, on Windows-based platforms, paths must be less than 248 characters, and file names must be less than 260 characters.
+        /// </exception>
+        /// <exception cref="DirectoryNotFoundException">The specified path is invalid (for example, it is on an unmapped drive).</exception>
+        /// <exception cref="IOException">An I/O error occurred while opening the file.</exception>
+        /// <exception cref="UnauthorizedAccessException">
+        /// path specified a file that is read-only.
+        /// -or-
+        /// This operation is not supported on the current platform.
+        /// -or-
+        /// path specified a directory.
+        /// -or-
+        /// The caller does not have the required permission.
+        /// </exception>
+        /// <exception cref="FileNotFoundException">The file specified in <paramref name="path"/> was not found.</exception>
+        /// <exception cref="NotSupportedException"><paramref name="path"/> is in an invalid format.</exception>
+        /// <exception cref="System.Security.SecurityException">The caller does not have the required permission.</exception>
+        /// <remarks>
+        /// Given a string and a file path, this method opens the specified file, writes the string to the file using the specified encoding, and then closes the file.
+        /// The file handle is guaranteed to be closed by this method, even if exceptions are raised.
+        /// </remarks>
+        public override void WriteAllText(string path, string contents, Encoding encoding)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+            VerifyValueIsNotNull(path, "path");
+
+            if (mockFileDataAccessor.Directory.Exists(path))
+            {
+                throw new UnauthorizedAccessException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("ACCESS_TO_THE_PATH_IS_DENIED"), path));
+            }
+
+            VerifyDirectoryExists(path);
+
+            MockFileData data = contents == null ? new MockFileData(new byte[0]) : new MockFileData(contents, encoding);
+            mockFileDataAccessor.AddFile(path, data);
+        }
+
+        internal static string ReadAllBytes(byte[] contents, Encoding encoding)
+        {
+            using (var ms = new MemoryStream(contents))
+            using (var sr = new StreamReader(ms, encoding))
+            {
+                return sr.ReadToEnd();
+            }
+        }
+
+        private string ReadAllTextInternal(string path, Encoding encoding)
+        {
+            var mockFileData = mockFileDataAccessor.GetFile(path);
+            return ReadAllBytes(mockFileData.Contents, encoding);
+        }
+
+        private void VerifyValueIsNotNull(object value, string parameterName)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(parameterName, StringResources.Manager.GetString("VALUE_CANNOT_BE_NULL"));
+            }
+        }
+
+        private void VerifyDirectoryExists(string path)
+        {
+            DirectoryInfoBase dir = mockFileDataAccessor.Directory.GetParent(path);
+            if (!dir.Exists)
+            {
+                throw new DirectoryNotFoundException(
+                    string.Format(
+                        CultureInfo.InvariantCulture, 
+                        StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), 
+                        dir));
+            }
+        }
+    }
+}

--- a/src/MockFileData.cs
+++ b/src/MockFileData.cs
@@ -1,0 +1,165 @@
+﻿using System.Linq;
+using System.Security.AccessControl;
+using System.Text;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    /// <summary>
+    /// The class represents the associated data of a file.
+    /// </summary>
+    [Serializable]
+    public class MockFileData
+    {
+        /// <summary>
+        /// The default encoding.
+        /// </summary>
+        public static readonly Encoding DefaultEncoding = new UTF8Encoding(false, true);
+
+        /// <summary>
+        /// The null object.
+        /// </summary>
+        public static readonly MockFileData NullObject = new MockFileData(string.Empty)
+        {
+            LastWriteTime = new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc),
+            LastAccessTime = new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc),
+            CreationTime = new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc),
+            Attributes = FileAttributes.Normal,
+        };
+
+        /// <summary>
+        /// Gets the default date time offset.
+        /// E.g. for not existing files.
+        /// </summary>
+        public static readonly DateTimeOffset DefaultDateTimeOffset = new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc);
+
+        /// <summary>
+        /// The access control of the <see cref="MockFileData"/>.
+        /// </summary>
+        [NonSerialized]
+        private FileSecurity accessControl;
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="MockFileData"/> is a directory or not.
+        /// </summary>
+        public virtual bool IsDirectory { get { return false; } }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MockFileData"/> class with an empty content.
+        /// </summary>
+        private MockFileData()
+        {
+            // empty
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MockFileData"/> class with the content of <paramref name="textContents"/> using the encoding of <see cref="DefaultEncoding"/>.
+        /// </summary>
+        /// <param name="textContents">The textual content encoded into bytes with <see cref="DefaultEncoding"/>.</param>
+        public MockFileData(string textContents)
+            : this(DefaultEncoding.GetBytes(textContents))
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MockFileData"/> class with the content of <paramref name="textContents"/> using the encoding of <paramref name="encoding"/>.
+        /// </summary>
+        /// <param name="textContents">The textual content.</param>
+        /// <param name="encoding">The specific encoding used the encode the text.</param>
+        /// <remarks>The constructor respect the BOM of <paramref name="encoding"/>.</remarks>
+        public MockFileData(string textContents, Encoding encoding)
+            : this()
+        {
+            Contents = encoding.GetPreamble().Concat(encoding.GetBytes(textContents)).ToArray();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MockFileData"/> class with the content of <paramref name="contents"/>.
+        /// </summary>
+        /// <param name="contents">The actual content.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="contents"/> is <see langword="null" />.</exception>
+        public MockFileData(byte[] contents)
+        {
+            Contents = contents ?? throw new ArgumentNullException(nameof(contents));
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MockFileData"/> class by copying the given <see cref="MockFileData"/>.
+        /// </summary>
+        /// <param name="template">The template instance.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="template"/> is <see langword="null" />.</exception>
+        public MockFileData(MockFileData template)
+        {
+            if (template == null)
+            {
+                throw new ArgumentNullException(nameof(template));
+            }
+
+            accessControl = template.accessControl;
+            Attributes = template.Attributes;
+            Contents = template.Contents.ToArray();
+            CreationTime = template.CreationTime;
+            LastAccessTime = template.LastAccessTime;
+            LastWriteTime = template.LastWriteTime;
+        }
+
+        /// <summary>
+        /// Gets or sets the byte contents of the <see cref="MockFileData"/>.
+        /// </summary>
+        public byte[] Contents { get; set; }
+
+        /// <summary>
+        /// Gets or sets the string contents of the <see cref="MockFileData"/>.
+        /// </summary>
+        /// <remarks>
+        /// The setter uses the <see cref="DefaultEncoding"/> using this can scramble the actual contents.
+        /// </remarks>
+        public string TextContents
+        {
+            get { return MockFile.ReadAllBytes(Contents, DefaultEncoding); }
+            set { Contents = DefaultEncoding.GetBytes(value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the date and time the <see cref="MockFileData"/> was created.
+        /// </summary>
+        public DateTimeOffset CreationTime { get; set; } = new DateTimeOffset(2010, 01, 02, 00, 00, 00, TimeSpan.FromHours(4));
+
+        /// <summary>
+        /// Gets or sets the date and time of the <see cref="MockFileData"/> was last accessed to.
+        /// </summary>
+        public DateTimeOffset LastAccessTime { get; set; } = new DateTimeOffset(2010, 02, 04, 00, 00, 00, TimeSpan.FromHours(4));
+
+        /// <summary>
+        /// Gets or sets the date and time of the <see cref="MockFileData"/> was last written to.
+        /// </summary>
+        public DateTimeOffset LastWriteTime { get; set; } = new DateTimeOffset(2010, 01, 04, 00, 00, 00, TimeSpan.FromHours(4));
+
+        /// <summary>
+        /// Casts a string into <see cref="MockFileData"/>.
+        /// </summary>
+        /// <param name="s">The path of the <see cref="MockFileData"/> to be created.</param>
+        public static implicit operator MockFileData(string s)
+        {
+            return new MockFileData(s);
+        }
+
+        /// <summary>
+        /// Gets or sets the specified <see cref="FileAttributes"/> of the <see cref="MockFileData"/>.
+        /// </summary>
+        public FileAttributes Attributes { get; set; } = FileAttributes.Normal;
+
+        /// <summary>
+        /// Gets or sets <see cref="FileSecurity"/> of the <see cref="MockFileData"/>. This is the object that is returned for this <see cref="MockFileData"/> when calling <see cref="FileBase.GetAccessControl(string)"/>.
+        /// </summary>
+        public FileSecurity AccessControl
+        {
+            get
+            {
+                // FileSecurity's constructor will throw PlatformNotSupportedException on non-Windows platform, so we initialize it in lazy way.
+                // This let's us use this class as long as we don't use AccessControl property.
+                return accessControl ?? (accessControl = new FileSecurity());
+            }
+            set { accessControl = value; }
+        }
+    }
+}

--- a/src/MockFileInfo.cs
+++ b/src/MockFileInfo.cs
@@ -1,0 +1,315 @@
+﻿using System.Security.AccessControl;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    [Serializable]
+    public class MockFileInfo : FileInfoBase
+    {
+        private readonly IMockFileDataAccessor mockFileSystem;
+        private string path;
+
+        public MockFileInfo(IMockFileDataAccessor mockFileSystem, string path) : base(mockFileSystem?.FileSystem)
+        {
+            this.mockFileSystem = mockFileSystem ?? throw new ArgumentNullException(nameof(mockFileSystem));
+            this.path = path ?? throw new ArgumentNullException(nameof(path));
+        }
+
+        MockFileData MockFileData
+        {
+            get { return mockFileSystem.GetFile(path); }
+        }
+
+        public override void Delete()
+        {
+            mockFileSystem.RemoveFile(path);
+        }
+
+        public override void Refresh()
+        {
+        }
+
+        public override FileAttributes Attributes
+        {
+            get
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                return MockFileData.Attributes;
+            }
+            set { MockFileData.Attributes = value; }
+        }
+
+        public override DateTime CreationTime
+        {
+            get
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                return MockFileData.CreationTime.DateTime;
+            }
+            set
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                MockFileData.CreationTime = value;
+            }
+        }
+
+        public override DateTime CreationTimeUtc
+        {
+            get
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                return MockFileData.CreationTime.UtcDateTime;
+            }
+            set
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                MockFileData.CreationTime = value.ToLocalTime();
+            }
+        }
+
+        public override bool Exists
+        {
+            get { return MockFileData != null; }
+        }
+
+        public override string Extension
+        {
+            get
+            {
+                // System.IO.Path.GetExtension does only string manipulation,
+                // so it's safe to delegate.
+                return Path.GetExtension(path);
+            }
+        }
+
+        public override string FullName
+        {
+            get { return path; }
+        }
+
+        public override DateTime LastAccessTime
+        {
+            get
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                return MockFileData.LastAccessTime.DateTime;
+            }
+            set
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                MockFileData.LastAccessTime = value;
+            }
+        }
+
+        public override DateTime LastAccessTimeUtc
+        {
+            get
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                return MockFileData.LastAccessTime.UtcDateTime;
+            }
+            set
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                MockFileData.LastAccessTime = value;
+            }
+        }
+
+        public override DateTime LastWriteTime
+        {
+            get
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                return MockFileData.LastWriteTime.DateTime;
+            }
+            set
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                MockFileData.LastWriteTime = value;
+            }
+        }
+
+        public override DateTime LastWriteTimeUtc
+        {
+            get
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                return MockFileData.LastWriteTime.UtcDateTime;
+            }
+            set
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                MockFileData.LastWriteTime = value.ToLocalTime();
+            }
+        }
+
+        public override string Name
+        {
+            get { return new MockPath(mockFileSystem).GetFileName(path); }
+        }
+
+        public override StreamWriter AppendText()
+        {
+            if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+            return new StreamWriter(new MockFileStream(mockFileSystem, FullName, MockFileStream.StreamType.APPEND));
+        }
+
+        public override FileInfoBase CopyTo(string destFileName)
+        {
+            return CopyTo(destFileName, false);
+        }
+
+        public override FileInfoBase CopyTo(string destFileName, bool overwrite)
+        {
+            if (!Exists)
+            {
+                throw new FileNotFoundException("The file does not exist and can't be moved or copied.", FullName);
+            }
+            if (destFileName == FullName)
+            {
+                return this;
+            }
+            new MockFile(mockFileSystem).Copy(FullName, destFileName, overwrite);
+            return mockFileSystem.FileInfo.FromFileName(destFileName);
+        }
+
+        public override Stream Create()
+        {
+            return new MockFile(mockFileSystem).Create(FullName);
+        }
+
+        public override StreamWriter CreateText()
+        {
+            return new MockFile(mockFileSystem).CreateText(FullName);
+        }
+
+#if NET40
+        public override void Decrypt()
+        {
+            if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+
+            MockFileData.Attributes &= ~FileAttributes.Encrypted;
+        }
+
+        public override void Encrypt()
+        {
+            if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+
+            MockFileData.Attributes |= FileAttributes.Encrypted;
+        }
+#endif
+
+        public override FileSecurity GetAccessControl()
+        {
+            return mockFileSystem.File.GetAccessControl(this.path);
+        }
+
+        public override FileSecurity GetAccessControl(AccessControlSections includeSections)
+        {
+            return mockFileSystem.File.GetAccessControl(this.path, includeSections);
+        }
+
+        public override void MoveTo(string destFileName)
+        {
+            var movedFileInfo = CopyTo(destFileName);
+            if (destFileName == FullName)
+            {
+                return;
+            }
+            Delete();
+            path = movedFileInfo.FullName;
+        }
+
+        public override Stream Open(FileMode mode)
+        {
+            return new MockFile(mockFileSystem).Open(FullName, mode);
+        }
+
+        public override Stream Open(FileMode mode, FileAccess access)
+        {
+            return new MockFile(mockFileSystem).Open(FullName, mode, access);
+        }
+
+        public override Stream Open(FileMode mode, FileAccess access, FileShare share)
+        {
+            return new MockFile(mockFileSystem).Open(FullName, mode, access, share);
+        }
+
+        public override Stream OpenRead()
+        {
+            if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+            return new MockFileStream(mockFileSystem, path, MockFileStream.StreamType.READ);
+        }
+
+        public override StreamReader OpenText()
+        {
+          return new StreamReader(OpenRead());
+        }
+
+        public override Stream OpenWrite()
+        {
+            return new MockFileStream(mockFileSystem, path, MockFileStream.StreamType.WRITE);
+        }
+
+#if NET40
+        public override FileInfoBase Replace(string destinationFileName, string destinationBackupFileName)
+        {
+            return Replace(destinationFileName, destinationBackupFileName, false);
+        }
+
+        public override FileInfoBase Replace(string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
+        {
+            mockFileSystem.File.Replace(path, destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
+            return mockFileSystem.FileInfo.FromFileName(destinationFileName);
+        }
+#endif
+
+        public override void SetAccessControl(FileSecurity fileSecurity)
+        {
+            mockFileSystem.File.SetAccessControl(this.path, fileSecurity);
+        }
+
+        public override DirectoryInfoBase Directory
+        {
+            get
+            {
+                return mockFileSystem.DirectoryInfo.FromDirectoryName(DirectoryName);
+            }
+        }
+
+        public override string DirectoryName
+        {
+            get
+            {
+                // System.IO.Path.GetDirectoryName does only string manipulation,
+                // so it's safe to delegate.
+                return Path.GetDirectoryName(path);
+            }
+        }
+
+        public override bool IsReadOnly
+        {
+            get
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                return (MockFileData.Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly;
+            }
+            set
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                if(value)
+                    MockFileData.Attributes |= FileAttributes.ReadOnly;
+                else
+                    MockFileData.Attributes &= ~FileAttributes.ReadOnly;
+            }
+        }
+
+        public override long Length
+        {
+            get
+            {
+                if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+                return MockFileData.Contents.Length;
+            }
+        }
+    }
+}

--- a/src/MockFileInfoFactory.cs
+++ b/src/MockFileInfoFactory.cs
@@ -1,0 +1,18 @@
+﻿namespace System.IO.Abstractions.TestingHelpers
+{
+    [Serializable]
+    public class MockFileInfoFactory : IFileInfoFactory
+    {
+        private readonly IMockFileDataAccessor mockFileSystem;
+
+        public MockFileInfoFactory(IMockFileDataAccessor mockFileSystem)
+        {
+            this.mockFileSystem = mockFileSystem ?? throw new ArgumentNullException(nameof(mockFileSystem));
+        }
+
+        public FileInfoBase FromFileName(string fileName)
+        {
+            return new MockFileInfo(mockFileSystem, fileName);
+        }
+    }
+}

--- a/src/MockFileStream.cs
+++ b/src/MockFileStream.cs
@@ -1,0 +1,119 @@
+﻿namespace System.IO.Abstractions.TestingHelpers
+{
+    [Serializable]
+    public class MockFileStream : MemoryStream
+    {
+        private readonly IMockFileDataAccessor mockFileDataAccessor;
+        private readonly string path;
+        private readonly bool canWrite = true;
+        private readonly FileOptions options;
+        private bool disposed;
+
+        public enum StreamType
+        {
+            READ,
+            WRITE,
+            APPEND,
+            TRUNCATE
+        }
+
+        public MockFileStream(
+            IMockFileDataAccessor mockFileDataAccessor,
+            string path,
+            StreamType streamType)
+            : this(mockFileDataAccessor, path, streamType, FileOptions.None)
+        {
+        }
+
+        public MockFileStream(
+            IMockFileDataAccessor mockFileDataAccessor,
+            string path,
+            StreamType streamType,
+            FileOptions options)
+        {
+            this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
+            this.path = path;
+            this.options = options;
+
+            if (mockFileDataAccessor.FileExists(path))
+            {
+                /* only way to make an expandable MemoryStream that starts with a particular content */
+                var data = mockFileDataAccessor.GetFile(path).Contents;
+                if (data != null && data.Length > 0 && streamType != StreamType.TRUNCATE)
+                {
+                    Write(data, 0, data.Length);
+                    Seek(0, StreamType.APPEND.Equals(streamType)
+                        ? SeekOrigin.End
+                        : SeekOrigin.Begin);
+                }
+            }
+            else
+            {
+                if (StreamType.READ.Equals(streamType))
+                {
+                    throw new FileNotFoundException("File not found.", path);
+                }
+                mockFileDataAccessor.AddFile(path, new MockFileData(new byte[] { }));
+            }
+
+            canWrite = streamType != StreamType.READ;
+        }
+
+        public override bool CanWrite => canWrite;
+
+#if NET40
+        public override void Close()
+        {
+            InternalFlush();
+            OnClose();
+        }
+#else
+        protected override void Dispose(bool disposing)
+        {
+            if (disposed)
+            {
+                return;
+            }
+            InternalFlush();
+            base.Dispose(disposing);
+            OnClose();
+            disposed = true;
+        }
+#endif
+
+        public override void Flush()
+        {
+            InternalFlush();
+        }
+
+        private void InternalFlush()
+        {
+            if (mockFileDataAccessor.FileExists(path))
+            {
+                var mockFileData = mockFileDataAccessor.GetFile(path);
+                /* reset back to the beginning .. */
+                Seek(0, SeekOrigin.Begin);
+                /* .. read everything out */
+                var data = new byte[Length];
+                Read(data, 0, (int)Length);
+                /* .. put it in the mock system */
+                mockFileData.Contents = data;
+            }
+        }
+
+        private void OnClose()
+        {
+            if (options.HasFlag(FileOptions.DeleteOnClose) && mockFileDataAccessor.FileExists(path))
+            {
+                mockFileDataAccessor.RemoveFile(path);
+            }
+
+#if NET40
+            if (options.HasFlag(FileOptions.Encrypted) && mockFileDataAccessor.FileExists(path))
+            {
+                mockFileDataAccessor.FileInfo.FromFileName(path).Encrypt();
+            }
+#endif
+        }
+    }
+}

--- a/src/MockFileStreamFactory.cs
+++ b/src/MockFileStreamFactory.cs
@@ -1,0 +1,87 @@
+using System.Security.AccessControl;
+using Microsoft.Win32.SafeHandles;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    [Serializable]
+    public class MockFileStreamFactory : IFileStreamFactory
+    {
+        private readonly IMockFileDataAccessor mockFileSystem;
+
+        public MockFileStreamFactory(IMockFileDataAccessor mockFileSystem)
+            => this.mockFileSystem = mockFileSystem ?? throw new ArgumentNullException(nameof(mockFileSystem));
+
+        public Stream Create(string path, FileMode mode)
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode));
+
+        public Stream Create(string path, FileMode mode, FileAccess access)
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access));
+
+        public Stream Create(string path, FileMode mode, FileAccess access, FileShare share)
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access));
+
+        public Stream Create(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize)
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access));
+
+        public Stream Create(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access), options);
+
+        public Stream Create(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, bool useAsync)
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode, access));
+
+#if NET40
+        public Stream Create(string path, FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options, FileSecurity fileSecurity)
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode), options);
+
+        public Stream Create(string path, FileMode mode, FileSystemRights rights, FileShare share, int bufferSize, FileOptions options)
+            => new MockFileStream(mockFileSystem, path, GetStreamType(mode), options);
+#endif
+
+#if NET40 || NETSTANDARD_20
+        [Obsolete("This method has been deprecated. Please use new Create(SafeFileHandle handle, FileAccess access) instead. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public Stream Create(IntPtr handle, FileAccess access)
+            => new MockFileStream(mockFileSystem, handle.ToString(), GetStreamType(FileMode.Append, access));
+
+        [Obsolete("This method has been deprecated. Please use new Create(SafeFileHandle handle, FileAccess access) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public Stream Create(IntPtr handle, FileAccess access, bool ownsHandle)
+            => new MockFileStream(mockFileSystem, handle.ToString(), GetStreamType(FileMode.Append, access));
+
+        [Obsolete("This method has been deprecated. Please use new Create(SafeFileHandle handle, FileAccess access, int bufferSize) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public Stream Create(IntPtr handle, FileAccess access, bool ownsHandle, int bufferSize)
+            => new MockFileStream(mockFileSystem, handle.ToString(), GetStreamType(FileMode.Append, access));
+
+        [Obsolete("This method has been deprecated. Please use new Create(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync) instead, and optionally make a new SafeFileHandle with ownsHandle=false if needed. http://go.microsoft.com/fwlink/?linkid=14202")]
+        public Stream Create(IntPtr handle, FileAccess access, bool ownsHandle, int bufferSize, bool isAsync)
+            => new MockFileStream(mockFileSystem, handle.ToString(), GetStreamType(FileMode.Append, access));
+#endif
+
+        public Stream Create(SafeFileHandle handle, FileAccess access)
+            => new MockFileStream(mockFileSystem, handle.ToString(), GetStreamType(FileMode.Append, access));
+
+        public Stream Create(SafeFileHandle handle, FileAccess access, int bufferSize)
+            => new MockFileStream(mockFileSystem, handle.ToString(), GetStreamType(FileMode.Append, access));
+
+        public Stream Create(SafeFileHandle handle, FileAccess access, int bufferSize, bool isAsync)
+            => new MockFileStream(mockFileSystem, handle.ToString(), GetStreamType(FileMode.Append, access));
+
+        private static MockFileStream.StreamType GetStreamType(FileMode mode, FileAccess access = FileAccess.ReadWrite)
+        {
+            if (access == FileAccess.Read)
+            {
+                return MockFileStream.StreamType.READ;
+            }
+            else if (mode == FileMode.Append) 
+            {
+                return MockFileStream.StreamType.APPEND;
+            }
+            else if (mode == FileMode.Truncate)
+            {
+                return MockFileStream.StreamType.TRUNCATE;
+            }
+            else
+            {
+                return MockFileStream.StreamType.WRITE;
+            }
+        }
+    }
+}

--- a/src/MockFileSystem.cs
+++ b/src/MockFileSystem.cs
@@ -1,0 +1,337 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    [Serializable]
+    public class MockFileSystem : IFileSystem, IMockFileDataAccessor
+    {
+        private const string DEFAULT_CURRENT_DIRECTORY = @"C:\";
+
+        private readonly IDictionary<string, MockFileData> files;
+        [NonSerialized]
+        private readonly PathVerifier pathVerifier;
+
+        public MockFileSystem() : this(null) { }
+
+        public MockFileSystem(IDictionary<string, MockFileData> files, string currentDirectory = "")
+        {
+            if (string.IsNullOrEmpty(currentDirectory))
+            {
+                currentDirectory = XFS.Path(DEFAULT_CURRENT_DIRECTORY);
+            }
+
+            pathVerifier = new PathVerifier(this);
+
+            this.files = new Dictionary<string, MockFileData>(StringComparer.OrdinalIgnoreCase);
+            
+            Path = new MockPath(this);
+            File = new MockFile(this);
+            Directory = new MockDirectory(this, File, currentDirectory);
+            FileInfo = new MockFileInfoFactory(this);
+            FileStream = new MockFileStreamFactory(this);
+            DirectoryInfo = new MockDirectoryInfoFactory(this);
+            DriveInfo = new MockDriveInfoFactory(this);
+            FileSystemWatcher = new MockFileSystemWatcherFactory();
+
+            if (files != null)
+            {
+                foreach (var entry in files)
+                {
+                    AddFile(entry.Key, entry.Value);
+                }
+            }
+
+            if (!FileExists(currentDirectory))
+            {
+                AddDirectory(currentDirectory);
+            }
+        }
+
+        public FileBase File { get; }
+
+        public DirectoryBase Directory { get; }
+
+        public IFileInfoFactory FileInfo { get; }
+
+        public IFileStreamFactory FileStream { get; }
+
+        public PathBase Path { get; }
+
+        public IDirectoryInfoFactory DirectoryInfo { get; }
+
+        public IDriveInfoFactory DriveInfo { get; }
+
+        public IFileSystemWatcherFactory FileSystemWatcher { get; }
+
+        public IFileSystem FileSystem => this;
+
+        public PathVerifier PathVerifier => pathVerifier;
+
+        private string FixPath(string path, bool checkCaps = false)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path), StringResources.Manager.GetString("VALUE_CANNOT_BE_NULL"));
+            }
+            
+            var pathSeparatorFixed = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            var fullPath = Path.GetFullPath(pathSeparatorFixed);
+
+            return checkCaps ? GetPathWithCorrectDirectoryCapitalization(fullPath) : fullPath;
+        }
+
+        //If C:\foo exists, ensures that trying to save a file to "C:\FOO\file.txt" instead saves it to "C:\foo\file.txt".
+        private string GetPathWithCorrectDirectoryCapitalization(string fullPath)
+        {
+            string[] splitPath = fullPath.Split(Path.DirectorySeparatorChar);
+            string leftHalf = fullPath;
+            string rightHalf = "";
+
+            for (int i = splitPath.Length - 1; i > 1; i--)
+            {
+                rightHalf = i == splitPath.Length - 1 ? splitPath[i] : splitPath[i] + Path.DirectorySeparatorChar + rightHalf;
+                int lastSeparator = leftHalf.LastIndexOf(Path.DirectorySeparatorChar);
+                leftHalf = lastSeparator > 0 ? leftHalf.Substring(0, lastSeparator) : leftHalf;
+
+                if (Directory.Exists(leftHalf))
+                {
+                    leftHalf = Path.GetFullPath(leftHalf).TrimSlashes();
+                    string baseDirectory = AllDirectories.First(dir => dir.Equals(leftHalf, StringComparison.OrdinalIgnoreCase));
+                    return baseDirectory + Path.DirectorySeparatorChar + rightHalf;
+                }
+            }
+
+            return fullPath.TrimSlashes();
+        }
+
+        public MockFileData GetFile(string path)
+        {
+            path = FixPath(path).TrimSlashes();
+            return GetFileWithoutFixingPath(path);
+        }
+
+        private void SetEntry(string path, MockFileData mockFile)
+        {
+            path = FixPath(path, true).TrimSlashes();
+            files[path] = mockFile;
+        }
+
+        public void AddFile(string path, MockFileData mockFile)
+        {
+            var fixedPath = FixPath(path, true);
+            lock (files)
+            {
+                var file = GetFile(fixedPath);
+
+                if (file != null)
+                {
+                    var isReadOnly = (file.Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly;
+                    var isHidden = (file.Attributes & FileAttributes.Hidden) == FileAttributes.Hidden;
+
+                    if (isReadOnly || isHidden)
+                    {
+                        throw new UnauthorizedAccessException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("ACCESS_TO_THE_PATH_IS_DENIED"), path));
+                    }
+                }
+
+                var directoryPath = Path.GetDirectoryName(fixedPath);
+
+                if (!Directory.Exists(directoryPath))
+                {
+                    AddDirectory(directoryPath);
+                }
+
+                SetEntry(fixedPath, mockFile ?? new MockFileData(string.Empty));
+            }
+        }
+
+        public void AddDirectory(string path)
+        {
+            var fixedPath = FixPath(path, true);
+            var separator = XFS.Separator();
+
+            lock (files)
+            {
+                if (FileExists(fixedPath) &&
+                    (GetFile(fixedPath).Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+                    throw new UnauthorizedAccessException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("ACCESS_TO_THE_PATH_IS_DENIED"), fixedPath));
+
+                var lastIndex = 0;
+
+                bool isUnc =
+                    fixedPath.StartsWith(@"\\", StringComparison.OrdinalIgnoreCase) ||
+                    fixedPath.StartsWith(@"//", StringComparison.OrdinalIgnoreCase);
+
+                if (isUnc)
+                {
+                    //First, confirm they aren't trying to create '\\server\'
+                    lastIndex = fixedPath.IndexOf(separator, 2, StringComparison.OrdinalIgnoreCase);
+                    if (lastIndex < 0)
+                        throw new ArgumentException(@"The UNC path should be of the form \\server\share.", "path");
+
+                    /*
+                     * Although CreateDirectory(@"\\server\share\") is not going to work in real code, we allow it here for the purposes of setting up test doubles.
+                     * See PR https://github.com/System-IO-Abstractions/System.IO.Abstractions/pull/90 for conversation
+                     */
+                }
+
+                while ((lastIndex = fixedPath.IndexOf(separator, lastIndex + 1, StringComparison.OrdinalIgnoreCase)) > -1)
+                {
+                    var segment = fixedPath.Substring(0, lastIndex + 1);
+                    if (!Directory.Exists(segment))
+                    {
+                        SetEntry(segment, new MockDirectoryData());
+                    }
+                }
+
+                var s = fixedPath.EndsWith(separator, StringComparison.OrdinalIgnoreCase) ? fixedPath : fixedPath + separator;
+                SetEntry(s, new MockDirectoryData());
+            }
+        }
+
+        public void AddFileFromEmbeddedResource(string path, Assembly resourceAssembly, string embeddedResourcePath)
+        {
+            using (var embeddedResourceStream = resourceAssembly.GetManifestResourceStream(embeddedResourcePath))
+            {
+                if (embeddedResourceStream == null)
+                {
+                    throw new Exception("Resource not found in assembly");
+                }
+
+                using (var streamReader = new BinaryReader(embeddedResourceStream))
+                {
+                    var fileData = streamReader.ReadBytes((int)embeddedResourceStream.Length);
+                    AddFile(path, new MockFileData(fileData));
+                }
+            }
+        }
+
+        public void AddFilesFromEmbeddedNamespace(string path, Assembly resourceAssembly, string embeddedRresourcePath)
+        {
+            var matchingResources = resourceAssembly.GetManifestResourceNames().Where(f => f.StartsWith(embeddedRresourcePath));
+            foreach (var resource in matchingResources)
+            {
+                using (var embeddedResourceStream = resourceAssembly.GetManifestResourceStream(resource))
+                using (var streamReader = new BinaryReader(embeddedResourceStream))
+                {
+                    var fileName = resource.Substring(embeddedRresourcePath.Length + 1);
+                    var fileData = streamReader.ReadBytes((int)embeddedResourceStream.Length);
+                    var filePath = Path.Combine(path, fileName);
+                    AddFile(filePath, new MockFileData(fileData));
+                }
+            }
+        }
+
+        public void MoveDirectory(string sourcePath, string destPath)
+        {
+            sourcePath = FixPath(sourcePath);
+            destPath = FixPath(destPath);
+
+            lock (files)
+            {
+                var affectedPaths = files.Keys
+                    .Where(p => p.StartsWith(sourcePath, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+
+                foreach(var path in affectedPaths)
+                {
+                    var newPath = path.Replace(sourcePath, destPath, StringComparison.OrdinalIgnoreCase);
+                    files[newPath] = files[path];
+                    files.Remove(path);
+                }
+            }
+        }
+
+        public void RemoveFile(string path)
+        {
+            path = FixPath(path);
+
+            lock (files)
+            {
+                if (FileExists(path) && (GetFile(path).Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+                {
+                    throw new UnauthorizedAccessException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("ACCESS_TO_THE_PATH_IS_DENIED"), path));
+                }
+
+                files.Remove(path);
+            }
+        }
+
+        public bool FileExists(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return false;
+            }
+
+            path = FixPath(path).TrimSlashes();
+
+            lock (files)
+            {
+                return files.ContainsKey(path);
+            }
+        }
+
+        public IEnumerable<string> AllPaths
+        {
+            get
+            {
+                lock (files)
+                {
+                    return files.Keys.ToArray();
+                }
+            }
+        }
+
+        public IEnumerable<string> AllNodes
+        {
+            get
+            {
+                lock (files)
+                {
+                    return AllPaths.Where(path => !IsStartOfAnotherPath(path)).ToArray();
+                }
+            }
+        }
+
+        public IEnumerable<string> AllFiles
+        {
+            get
+            {
+                lock (files)
+                {
+                    return files.Where(f => !f.Value.IsDirectory).Select(f => f.Key).ToArray();
+                }
+            }
+        }
+
+        public IEnumerable<string> AllDirectories
+        {
+            get
+            {
+                lock (files)
+                {
+                    return files.Where(f => f.Value.IsDirectory).Select(f => f.Key).ToArray();
+                }
+            }
+        }
+
+        private bool IsStartOfAnotherPath(string path)
+        {
+            return AllPaths.Any(otherPath => otherPath.StartsWith(path) && otherPath != path);
+        }
+
+        private MockFileData GetFileWithoutFixingPath(string path)
+        {
+            lock (files)
+            {
+                files.TryGetValue(path, out var result);
+                return result;
+            }
+        }
+    }
+}

--- a/src/MockFileSystemWatcher.cs
+++ b/src/MockFileSystemWatcher.cs
@@ -1,0 +1,38 @@
+﻿using System.ComponentModel;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    public class MockFileSystemWatcher : FileSystemWatcherBase
+    {
+        public override bool IncludeSubdirectories { get; set; }
+        public override bool EnableRaisingEvents { get; set; }
+        public override string Filter { get; set; }
+        public override int InternalBufferSize { get; set; }
+        public override NotifyFilters NotifyFilter { get; set; }
+        public override string Path { get; set; }
+#if NET40
+        public override ISite Site { get; set; }
+        public override ISynchronizeInvoke SynchronizingObject { get; set; }
+#endif
+
+#if NET40
+        public override void BeginInit()
+        {
+        }
+
+        public override void EndInit()
+        {
+        }
+#endif
+
+        public override WaitForChangedResult WaitForChanged(WatcherChangeTypes changeType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override WaitForChangedResult WaitForChanged(WatcherChangeTypes changeType, int timeout)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/MockFileSystemWatcherFactory.cs
+++ b/src/MockFileSystemWatcherFactory.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    [Serializable]
+    public class MockFileSystemWatcherFactory : IFileSystemWatcherFactory
+    {
+        public FileSystemWatcherBase CreateNew()
+        {
+            return new MockFileSystemWatcher();
+        }
+
+        public FileSystemWatcherBase FromPath(string path)
+        {
+            return new MockFileSystemWatcher {Path = path};
+        }
+    }
+}

--- a/src/MockPath.cs
+++ b/src/MockPath.cs
@@ -1,0 +1,169 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    /// <summary>
+    /// PathWrapper calls direct to Path but all this does is string manipulation so we can inherit directly from PathWrapper as no IO is done
+    /// </summary>
+    [Serializable]
+    public class MockPath : PathWrapper
+    {
+        private readonly IMockFileDataAccessor mockFileDataAccessor;
+
+        private static readonly char[] InvalidAdditionalPathChars = { '*', '?' };
+
+        public MockPath(IMockFileDataAccessor mockFileDataAccessor) : base(mockFileDataAccessor?.FileSystem)
+        {
+            this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
+        }
+
+        public override string GetFullPath(string path)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path), StringResources.Manager.GetString("VALUE_CANNOT_BE_NULL"));
+            }
+
+            if (path.Length == 0)
+            {
+                throw new ArgumentException(StringResources.Manager.GetString("THE_PATH_IS_NOT_OF_A_LEGAL_FORM"), "path");
+            }
+
+            path = path.Replace(AltDirectorySeparatorChar, DirectorySeparatorChar);
+
+            bool isUnc =
+                path.StartsWith(@"\\", StringComparison.OrdinalIgnoreCase) ||
+                path.StartsWith(@"//", StringComparison.OrdinalIgnoreCase);
+
+            string root = GetPathRoot(path);
+
+            bool hasTrailingSlash = path.Length > 1 && path[path.Length - 1] == DirectorySeparatorChar;
+
+            string[] pathSegments;
+
+            if (root.Length == 0)
+            {
+                // relative path on the current drive or volume
+                path = mockFileDataAccessor.Directory.GetCurrentDirectory() + DirectorySeparatorChar + path;
+                pathSegments = GetSegments(path);
+            }
+            else if (isUnc)
+            {
+                // unc path
+                pathSegments = GetSegments(path);
+                if (pathSegments.Length < 2)
+                {
+                    throw new ArgumentException(@"The UNC path should be of the form \\server\share.", "path");
+                }
+            }
+            else if (@"\".Equals(root, StringComparison.OrdinalIgnoreCase) || @"/".Equals(root, StringComparison.OrdinalIgnoreCase))
+            {
+                // absolute path on the current drive or volume
+                pathSegments = GetSegments(GetPathRoot(mockFileDataAccessor.Directory.GetCurrentDirectory()), path);
+            }
+            else
+            {
+                pathSegments = GetSegments(path);
+            }
+
+            // unc paths need at least two segments, the others need one segment
+            bool isUnixRooted =
+                mockFileDataAccessor.Directory.GetCurrentDirectory()
+                    .StartsWith(string.Format(CultureInfo.InvariantCulture, "{0}", DirectorySeparatorChar), StringComparison.OrdinalIgnoreCase);
+
+            var minPathSegments = isUnc
+                ? 2
+                : isUnixRooted ? 0 : 1;
+
+            var stack = new Stack<string>();
+            foreach (var segment in pathSegments)
+            {
+                if ("..".Equals(segment, StringComparison.OrdinalIgnoreCase))
+                {
+                    // only pop, if afterwards are at least the minimal amount of path segments
+                    if (stack.Count > minPathSegments)
+                    {
+                        stack.Pop();
+                    }
+                }
+                else if (".".Equals(segment, StringComparison.OrdinalIgnoreCase))
+                {
+                    // ignore .
+                }
+                else
+                {
+                    stack.Push(segment);
+                }
+            }
+
+            var fullPath = string.Join(string.Format(CultureInfo.InvariantCulture, "{0}", DirectorySeparatorChar), stack.Reverse().ToArray());
+
+            if (hasTrailingSlash)
+            {
+                fullPath += DirectorySeparatorChar;
+            }
+
+            if (isUnixRooted && !isUnc)
+            {
+                fullPath = DirectorySeparatorChar + fullPath;
+            }
+            else if (isUnixRooted)
+            {
+                fullPath = @"//" + fullPath;
+            }
+            else if (isUnc)
+            {
+                fullPath = @"\\" + fullPath;
+            }
+
+            return fullPath;
+        }
+
+        private string[] GetSegments(params string[] paths)
+        {
+            return paths.SelectMany(path => path.Split(new[] { DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries)).ToArray();
+        }
+
+        public override string GetTempFileName()
+        {
+            string fileName = mockFileDataAccessor.Path.GetRandomFileName();
+            string tempDir = mockFileDataAccessor.Path.GetTempPath();
+
+            string fullPath = mockFileDataAccessor.Path.Combine(tempDir, fileName);
+
+            mockFileDataAccessor.AddFile(fullPath, new MockFileData(string.Empty));
+
+            return fullPath;
+        }
+
+        internal static bool HasIllegalCharacters(string path, bool checkAdditional)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            if (checkAdditional)
+            {
+                return path.IndexOfAny(Path.GetInvalidPathChars().Concat(InvalidAdditionalPathChars).ToArray()) >= 0;
+            }
+
+            return path.IndexOfAny(Path.GetInvalidPathChars()) >= 0;
+        }
+
+        internal static void CheckInvalidPathChars(string path, bool checkAdditional = false)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            if (HasIllegalCharacters(path, checkAdditional))
+            {
+                throw new ArgumentException(StringResources.Manager.GetString("ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION"));
+            }
+        }
+    }
+}

--- a/src/MockUnixSupport.cs
+++ b/src/MockUnixSupport.cs
@@ -1,0 +1,31 @@
+﻿using System.Text.RegularExpressions;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    public static class MockUnixSupport
+    {
+        public static string Path(string path, Func<bool> isUnixF = null)
+        {
+            var isUnix = isUnixF ?? IsUnixPlatform;
+
+            if (isUnix())
+            {
+                path = Regex.Replace(path, @"^[a-zA-Z]:(?<path>.*)$", "${path}");
+                path = path.Replace(@"\", "/");
+            }
+
+            return path;
+        }
+
+        public static string Separator(Func<bool> isUnixF = null)
+        {
+            var isUnix = isUnixF ?? IsUnixPlatform;
+            return isUnix() ? "/" : @"\";
+        }
+
+        public static bool IsUnixPlatform()
+        {
+            return IO.Path.DirectorySeparatorChar == '/';
+        }
+    }
+}

--- a/src/PathVerifier.cs
+++ b/src/PathVerifier.cs
@@ -1,0 +1,72 @@
+﻿using System.Linq;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    public class PathVerifier
+    {
+        private readonly IMockFileDataAccessor _mockFileDataAccessor;
+
+        internal PathVerifier(IMockFileDataAccessor mockFileDataAccessor)
+        {
+            _mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
+        }
+
+        public void IsLegalAbsoluteOrRelative(string path, string paramName)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(paramName, StringResources.Manager.GetString("VALUE_CANNOT_BE_NULL"));
+            }
+
+            if (path == string.Empty)
+            {
+                throw new ArgumentException("Empty file name is not legal.", paramName);
+            }
+
+            if (path.Trim() == string.Empty)
+            {
+                throw new ArgumentException(StringResources.Manager.GetString("THE_PATH_IS_NOT_OF_A_LEGAL_FORM"), paramName);
+            }
+
+            if (!MockUnixSupport.IsUnixPlatform())
+            {
+                if (!IsValidUseOfVolumeSeparatorChar(path))
+                {
+                    throw new NotSupportedException(StringResources.Manager.GetString("THE_PATH_IS_NOT_OF_A_LEGAL_FORM"));
+                }
+            }
+
+            if (ExtractFileName(path).IndexOfAny(_mockFileDataAccessor.Path.GetInvalidFileNameChars()) > -1)
+            {
+                throw new ArgumentException(StringResources.Manager.GetString("ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION"));
+            }
+
+            var filePath = ExtractFilePath(path);
+            if (MockPath.HasIllegalCharacters(filePath, false))
+            {
+                throw new ArgumentException(StringResources.Manager.GetString("ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION"));
+            }
+        }
+
+        private static bool IsValidUseOfVolumeSeparatorChar(string path)
+        {
+            var lastVolSepIndex = path.LastIndexOf(Path.VolumeSeparatorChar);
+            return lastVolSepIndex == -1 || lastVolSepIndex == 1 && char.IsLetter(path[0]);
+        }
+
+        private string ExtractFileName(string fullFileName)
+        {
+            return fullFileName.Split(
+                _mockFileDataAccessor.Path.DirectorySeparatorChar,
+                _mockFileDataAccessor.Path.AltDirectorySeparatorChar).Last();
+        }
+
+        private string ExtractFilePath(string fullFileName)
+        {
+            var extractFilePath = fullFileName.Split(
+                _mockFileDataAccessor.Path.DirectorySeparatorChar,
+                _mockFileDataAccessor.Path.AltDirectorySeparatorChar);
+            return string.Join(_mockFileDataAccessor.Path.DirectorySeparatorChar.ToString(), extractFilePath.Take(extractFilePath.Length - 1));
+        }
+    }
+}

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿using System.Runtime.CompilerServices;
+
+#if DEBUG
+[assembly: InternalsVisibleTo("System.IO.Abstractions.TestingHelpers.Tests")]
+#else
+    [assembly: InternalsVisibleTo("System.IO.Abstractions.TestingHelpers.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010051bf2aa00ba30d507d4cebcab1751dfa13768a6f5235ce52da572260e33a11f52b87707f858fe4bbe32cd51830a8dd73245f688902707fa797c07205ff9b5212f93760d52f6d13022a286ff7daa13a0cd9eb958e888fcd7d9ed1f7cf76b19a5391835a7b633418a5f584d10925d76810f782f6b814cc34a2326b438abdc3b5bd")]
+#endif

--- a/src/Properties/Resources.resx
+++ b/src/Properties/Resources.resx
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ACCESS_TO_THE_PATH_IS_DENIED" xml:space="preserve">
+    <value>Access to the path '{0}' is denied.</value>
+  </data>
+  <data name="COULD_NOT_FIND_PART_OF_PATH_EXCEPTION" xml:space="preserve">
+    <value>Could not find a part of the path '{0}'.</value>
+  </data>
+  <data name="ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION" xml:space="preserve">
+    <value>Illegal characters in path.</value>
+  </data>
+  <data name="NOT_IMPLEMENTED_EXCEPTION" xml:space="preserve">
+    <value>This test helper hasn't been implemented yet. They are implemented on an as-needed basis. As it seems like you need it, now would be a great time to send us a pull request over at https://github.com/System-IO-Abstractions/System.IO.Abstractions. You know, because it's open source and all.</value>
+  </data>
+  <data name="THE_PATH_IS_NOT_OF_A_LEGAL_FORM" xml:space="preserve">
+    <value>The path is not of a legal form.</value>
+  </data>
+  <data name="VALUE_CANNOT_BE_NULL" xml:space="preserve">
+    <value>Value cannot be null.</value>
+  </data>
+  <data name="PATH_CANNOT_BE_THE_EMPTY_STRING_OR_ALL_WHITESPACE" xml:space="preserve">
+    <value>Path cannot be the empty string or all whitespace.</value>
+  </data>
+  <data name="FILENAME_CANNOT_BE_NULL" xml:space="preserve">
+    <value>File name cannot be null.</value>
+  </data>
+  <data name="COULD_NOT_FIND_FILE_EXCEPTION" xml:space="preserve">
+    <value>Could not find file '{0}'.</value>
+  </data>
+</root>

--- a/src/StringExtensions.cs
+++ b/src/StringExtensions.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Text;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    public static class StringExtensions
+    {
+        [Pure]
+        public static string[] SplitLines(this string input)
+        {
+            var list = new List<string>();
+            using (var reader = new StringReader(input))
+            {
+                string str;
+                while ((str = reader.ReadLine()) != null)
+                {
+                    list.Add(str);
+                }
+            }
+
+            return list.ToArray();
+        }
+
+        [Pure]
+        public static string Replace(this string source, string oldValue, string newValue, StringComparison comparisonType)
+        {
+            // from http://stackoverflow.com/a/22565605 with some adaptions
+            if (string.IsNullOrEmpty(oldValue))
+            {
+                throw new ArgumentNullException(nameof(oldValue));
+            }
+
+            if (source.Length == 0)
+            {
+                return source;
+            }
+
+            if (newValue == null)
+            {
+                newValue = string.Empty;
+            }
+
+            var result = new StringBuilder();
+            int startingPos = 0;
+            int nextMatch;
+            while ((nextMatch = source.IndexOf(oldValue, startingPos, comparisonType)) > -1)
+            {
+                result.Append(source, startingPos, nextMatch - startingPos);
+                result.Append(newValue);
+                startingPos = nextMatch + oldValue.Length;
+            }
+
+            result.Append(source, startingPos, source.Length - startingPos);
+
+            return result.ToString();
+        }
+
+        [Pure]
+        public static string TrimSlashes(this string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            var trimmed = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            if (MockUnixSupport.IsUnixPlatform()
+                && (path[0] == Path.DirectorySeparatorChar || path[0] == Path.AltDirectorySeparatorChar)
+                && trimmed == "")
+            {
+                return Path.DirectorySeparatorChar.ToString();
+            }
+
+            if (!MockUnixSupport.IsUnixPlatform()
+                && trimmed.Length == 2
+                && char.IsLetter(trimmed[0])
+                && trimmed[1] == ':')
+            {
+                return trimmed + Path.DirectorySeparatorChar;
+            }
+
+            return trimmed;
+        }
+    }
+}

--- a/src/StringResources.cs
+++ b/src/StringResources.cs
@@ -1,0 +1,15 @@
+﻿using System.Reflection;
+using System.Resources;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    internal static class StringResources
+    {
+        public static ResourceManager Manager { get; } = new ResourceManager(
+#if NET40
+            $"{typeof(StringResources).Namespace}.Properties.Resources", typeof(StringResources).Assembly);
+#else
+            $"{typeof(StringResources).Namespace}.Properties.Resources", typeof(StringResources).GetTypeInfo().Assembly);
+#endif
+    }
+}

--- a/src/System.IO.Abstractions.TestingHelpers.csproj
+++ b/src/System.IO.Abstractions.TestingHelpers.csproj
@@ -1,0 +1,46 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>net40;netstandard1.4;netstandard2.0;</TargetFrameworks>
+        <PackageId>System.IO.Abstractions.TestingHelpers</PackageId>
+        <Description>A set of pre-built mocks to help when testing file system interactions.</Description>
+        <Company />
+        <Product>System.IO.Abstractions</Product>
+        <Copyright>Copyright © Tatham Oddie 2010</Copyright>
+        <Authors>Tatham Oddie &amp; friends</Authors>
+        <RootNamespace>System.IO.Abstractions.TestingHelpers</RootNamespace>
+        <AssemblyOriginatorKeyFile>../StrongName.snk</AssemblyOriginatorKeyFile>
+        <PackageLicenseUrl>https://github.com/System-IO-Abstractions/System.IO.Abstractions/blob/master/LICENSE</PackageLicenseUrl>
+        <PackageProjectUrl>https://github.com/System-IO-Abstractions/System.IO.Abstractions</PackageProjectUrl>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <SignAssembly>False</SignAssembly>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <SignAssembly>True</SignAssembly>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\System.IO.Abstractions\System.IO.Abstractions.csproj" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+        <Reference Include="System" />
+        <Reference Include="Microsoft.CSharp" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
+        <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
+        <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
+        <PackageReference Include="System.Security.AccessControl" Version="4.5.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+    </ItemGroup>
+
+</Project>

--- a/tests/ConvertersTests.cs
+++ b/tests/ConvertersTests.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class ConvertersTests
+    {
+        private sealed class CrashingEnumerable<T> : IEnumerable<T>
+        {
+            private sealed class CrashingEnumerator : IEnumerator<T>
+            {
+                object IEnumerator.Current => throw new NotSupportedException();
+
+                public T Current => throw new NotSupportedException();
+
+                public bool MoveNext() { throw new NotSupportedException(); }
+
+                public void Reset() { }
+
+                public void Dispose() { }
+            }
+            
+            public IEnumerator<T> GetEnumerator() => new CrashingEnumerator();
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        [Test]
+        public void WrapFileSystemInfos_with_IEnumerable_is_lazy()
+        {
+            var crashingFileSystemInfos = new CrashingEnumerable<FileSystemInfo>();
+        
+            Assert.DoesNotThrow(() => crashingFileSystemInfos.WrapFileSystemInfos(new MockFileSystem()));
+        }
+
+        [Test]
+        public void WrapFiles_with_IEnumerable_is_lazy()
+        {
+            var crashingFileInfos = new CrashingEnumerable<FileInfo>();
+        
+            Assert.DoesNotThrow(() => crashingFileInfos.WrapFiles(new MockFileSystem()));
+        }
+        [Test]
+        public void WrapDirectories_with_IEnumerable_is_lazy()
+        {
+            var crashingDirectoryInfos = new CrashingEnumerable<DirectoryInfo>();
+        
+            Assert.DoesNotThrow(() => crashingDirectoryInfos.WrapDirectories(new MockFileSystem()));
+        }
+
+    }
+}

--- a/tests/FileInfoBaseConversionTests.cs
+++ b/tests/FileInfoBaseConversionTests.cs
@@ -1,0 +1,26 @@
+﻿namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Unit tests for the conversion operators of the <see cref="FileInfoBase"/> class.
+    /// </summary>
+    public class FileInfoBaseConversionTests
+    {
+        /// <summary>
+        /// Tests that a <c>null</c> <see cref="FileInfo"/> is correctly converted to a <c>null</c> <see cref="FileInfoBase"/> without exception.
+        /// </summary>
+        [Test]
+        public void FileInfoBase_FromFileInfo_ShouldReturnNullIfFileInfoIsNull()
+        {
+            // Arrange
+            FileInfo fileInfo = null;
+
+            // Act
+            FileInfoBase actual = fileInfo;
+
+            // Assert
+            Assert.IsNull(actual);
+        }
+    }
+}

--- a/tests/FileSystemTests.cs
+++ b/tests/FileSystemTests.cs
@@ -1,0 +1,106 @@
+﻿
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class FileSystemTests
+    {
+#if NET40
+        [Test]
+        public void Is_Serializable()
+        {
+            var fileSystem = new FileSystem();
+            var memoryStream = new MemoryStream();
+
+            var serializer = new Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+            serializer.Serialize(memoryStream, fileSystem);
+
+            Assert.That(memoryStream.Length > 0, "Length didn't increase after serialization task.");
+        }
+#endif
+
+#if NETCOREAPP2_0
+        [Test]
+        public void Mock_File_Succeeds()
+        {
+            var fileSystemMock = new Moq.Mock<IFileSystem>();
+
+            Assert.DoesNotThrow(() =>
+                fileSystemMock.Setup(x => x.File.ToString()).Returns("")
+            );
+        }
+       
+        [Test]
+        public void Mock_Directory_Succeeds()
+        {
+            var fileSystemMock = new Moq.Mock<IFileSystem>();
+
+            Assert.DoesNotThrow(() =>
+                fileSystemMock.Setup(x => x.Directory.ToString()).Returns("")
+            );
+        }
+       
+        [Test]
+        public void Mock_FileInfo_Succeeds()
+        {
+            var fileSystemMock = new Moq.Mock<IFileSystem>();
+
+            Assert.DoesNotThrow(() =>
+                fileSystemMock.Setup(x => x.FileInfo.ToString()).Returns("")
+            );
+        }
+       
+        [Test]
+        public void Mock_FileStream_Succeeds()
+        {
+            var fileSystemMock = new Moq.Mock<IFileSystem>();
+
+            Assert.DoesNotThrow(() =>
+                fileSystemMock.Setup(x => x.FileStream.ToString()).Returns("")
+            );
+        }
+
+        [Test]
+        public void Mock_Path_Succeeds()
+        {
+            var fileSystemMock = new Moq.Mock<IFileSystem>();
+
+            Assert.DoesNotThrow(() =>
+                fileSystemMock.Setup(x => x.Path.ToString()).Returns("")
+            );
+        }
+
+        [Test]
+        public void Mock_DirectoryInfo_Succeeds()
+        {
+            var fileSystemMock = new Moq.Mock<IFileSystem>();
+
+            Assert.DoesNotThrow(() =>
+                fileSystemMock.Setup(x => x.DirectoryInfo.ToString()).Returns("")
+            );
+        }
+
+        [Test]
+        public void Mock_DriveInfo_Succeeds()
+        {
+            var fileSystemMock = new Moq.Mock<IFileSystem>();
+
+            Assert.DoesNotThrow(() =>
+                fileSystemMock.Setup(x => x.DirectoryInfo.ToString()).Returns("")
+            );
+        }
+
+        [Test]
+        public void Mock_FileSystemWatcher_Succeeds()
+        {
+            var fileSystemMock = new Moq.Mock<IFileSystem>();
+
+            Assert.DoesNotThrow(() =>
+                fileSystemMock.Setup(x => x.FileSystemWatcher.ToString()).Returns("")
+            );
+        }
+#endif
+
+    }
+}

--- a/tests/MockDirectoryArgumentPathTests.cs
+++ b/tests/MockDirectoryArgumentPathTests.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Security.AccessControl;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    public class MockDirectoryArgumentPathTests
+    {
+        private static IEnumerable<Action<DirectoryBase>> GetFileSystemActionsForArgumentNullException()
+        {
+            yield return ds => ds.Delete(null);
+            yield return ds => ds.Delete(null, true);
+            yield return ds => ds.CreateDirectory(null);
+#if NET40
+            yield return ds => ds.CreateDirectory(null, new DirectorySecurity());
+#endif
+            yield return ds => ds.SetCreationTime(null, DateTime.Now);
+            yield return ds => ds.SetCreationTimeUtc(null, DateTime.Now);
+            yield return ds => ds.SetLastAccessTime(null, DateTime.Now);
+            yield return ds => ds.SetLastAccessTimeUtc(null, DateTime.Now);
+            yield return ds => ds.SetLastWriteTime(null, DateTime.Now);
+            yield return ds => ds.SetLastWriteTimeUtc(null, DateTime.Now);
+            yield return ds => ds.EnumerateDirectories(null);
+            yield return ds => ds.EnumerateDirectories(null, "foo");
+            yield return ds => ds.EnumerateDirectories(null, "foo", SearchOption.AllDirectories);
+        }
+
+        [TestCaseSource("GetFileSystemActionsForArgumentNullException")]
+        public void Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(Action<DirectoryBase> action)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate wrapped = () => action(fileSystem.Directory);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentNullException>(wrapped);
+            Assert.AreEqual("path", exception.ParamName);
+        }
+    }
+}

--- a/tests/MockDirectoryGetAccessControlTests.cs
+++ b/tests/MockDirectoryGetAccessControlTests.cs
@@ -1,0 +1,70 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Security.AccessControl;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    [WindowsOnly(WindowsSpecifics.AccessControlLists)]
+    public class MockDirectoryGetAccessControlTests
+    {
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockDirectory_GetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.GetAccessControl(path);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockDirectory_GetAccessControl_ShouldThrowDirectoryNotFoundExceptionIfDirectoryDoesNotExistInMockData()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var expectedDirectoryName = XFS.Path(@"c:\a");
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.GetAccessControl(expectedDirectoryName);
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockDirectory_GetAccessControl_ShouldReturnAccessControlOfDirectoryData()
+        {
+            // Arrange
+            var expectedDirectorySecurity = new DirectorySecurity();
+            expectedDirectorySecurity.SetAccessRuleProtection(false, false);
+
+            var filePath = XFS.Path(@"c:\a\");
+            var fileData = new MockDirectoryData()
+            {
+                AccessControl = expectedDirectorySecurity,
+            };
+
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { filePath, fileData }
+            });
+
+            // Act
+            var directorySecurity = fileSystem.Directory.GetAccessControl(filePath);
+
+            // Assert
+            Assert.That(directorySecurity, Is.EqualTo(expectedDirectorySecurity));
+        }
+    }
+}

--- a/tests/MockDirectoryInfoAccessControlTests.cs
+++ b/tests/MockDirectoryInfoAccessControlTests.cs
@@ -1,0 +1,63 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using System.Security.AccessControl;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    [WindowsOnly(WindowsSpecifics.AccessControlLists)]
+    public class MockDirectoryInfoAccessControlTests
+    {
+        [Test]
+        public void MockDirectoryInfo_GetAccessControl_ShouldReturnAccessControlOfDirectoryData()
+        {
+            // Arrange
+            var expectedDirectorySecurity = new DirectorySecurity();
+            expectedDirectorySecurity.SetAccessRuleProtection(false, false);
+
+            var filePath = XFS.Path(@"c:\a\");
+            var fileData = new MockDirectoryData()
+            {
+                AccessControl = expectedDirectorySecurity,
+            };
+
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { filePath, fileData }
+            });
+
+            var directorInfo = fileSystem.DirectoryInfo.FromDirectoryName(filePath);
+
+            // Act
+            var directorySecurity = directorInfo.GetAccessControl();
+
+            // Assert
+            Assert.That(directorySecurity, Is.EqualTo(expectedDirectorySecurity));
+        }
+
+        [Test]
+        public void MockDirectoryInfo_SetAccessControl_ShouldSetAccessControlOfDirectoryData()
+        {
+            // Arrange
+            var filePath = XFS.Path(@"c:\a\");
+            var fileData = new MockDirectoryData();
+
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { filePath, fileData }
+            });
+
+            var directorInfo = fileSystem.DirectoryInfo.FromDirectoryName(filePath);
+
+            // Act
+            var expectedAccessControl = new DirectorySecurity();
+            expectedAccessControl.SetAccessRuleProtection(false, false);
+            directorInfo.SetAccessControl(expectedAccessControl);
+
+            // Assert
+            var accessControl = directorInfo.GetAccessControl();
+            Assert.That(accessControl, Is.EqualTo(expectedAccessControl));
+        }
+    }
+}

--- a/tests/MockDirectoryInfoTests.cs
+++ b/tests/MockDirectoryInfoTests.cs
@@ -1,0 +1,291 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    public class MockDirectoryInfoTests
+    {
+        public static IEnumerable<object[]> MockDirectoryInfo_GetExtension_Cases
+        {
+            get
+            {
+                yield return new object[] { XFS.Path(@"c:\temp") };
+                yield return new object[] { XFS.Path(@"c:\temp\") };
+            }
+        }
+
+        [TestCaseSource("MockDirectoryInfo_GetExtension_Cases")]
+        public void MockDirectoryInfo_GetExtension_ShouldReturnEmptyString(string directoryPath)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var directoryInfo = new MockDirectoryInfo(fileSystem, directoryPath);
+
+            // Act
+            var result = directoryInfo.Extension;
+
+            // Assert
+            Assert.AreEqual(string.Empty, result);
+        }
+
+        public static IEnumerable<object[]> MockDirectoryInfo_Exists_Cases
+        {
+            get
+            {
+                yield return new object[]{ XFS.Path(@"c:\temp\folder"), true };
+                yield return new object[]{ XFS.Path(@"c:\temp\folder\notExistant"), false };
+            }
+        }
+
+        [TestCaseSource("MockDirectoryInfo_Exists_Cases")]
+        public void MockDirectoryInfo_Exists(string path, bool expected)
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {XFS.Path(@"c:\temp\folder\file.txt"), new MockFileData("Hello World")}
+            });
+            var directoryInfo = new MockDirectoryInfo(fileSystem, path);
+
+            var result = directoryInfo.Exists;
+
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void MockDirectoryInfo_FullName_ShouldReturnFullNameWithoutIncludingTrailingPathDelimiter()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {
+                    XFS.Path(@"c:\temp\folder\file.txt"),
+                        new MockFileData("Hello World")
+                }
+            });
+            var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
+
+            var result = directoryInfo.FullName;
+
+            Assert.That(result, Is.EqualTo(XFS.Path(@"c:\temp\folder")));
+        }
+
+        [Test]
+        public void MockDirectoryInfo_GetFileSystemInfos_ShouldReturnBothDirectoriesAndFiles()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\temp\folder\file.txt"), new MockFileData("Hello World") },
+                { XFS.Path(@"c:\temp\folder\folder"), new MockDirectoryData() }
+            });
+
+            var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
+            var result = directoryInfo.GetFileSystemInfos();
+
+            Assert.That(result.Length, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void MockDirectoryInfo_EnumerateFileSystemInfos_ShouldReturnBothDirectoriesAndFiles()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\temp\folder\file.txt"), new MockFileData("Hello World") },
+                { XFS.Path(@"c:\temp\folder\folder"), new MockDirectoryData() }
+            });
+
+            var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
+            var result = directoryInfo.EnumerateFileSystemInfos().ToArray();
+
+            Assert.That(result.Length, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void MockDirectoryInfo_GetFileSystemInfos_ShouldReturnDirectoriesAndNamesWithSearchPattern()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\temp\folder\file.txt"), new MockFileData("Hello World") },
+                { XFS.Path(@"c:\temp\folder\folder"), new MockDirectoryData() },
+                { XFS.Path(@"c:\temp\folder\older"), new MockDirectoryData() }
+            });
+
+            var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
+            var result = directoryInfo.GetFileSystemInfos("f*");
+
+            Assert.That(result.Length, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void MockDirectoryInfo_EnumerateFileSystemInfos_ShouldReturnDirectoriesAndNamesWithSearchPattern()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\temp\folder\file.txt"), new MockFileData("Hello World") },
+                { XFS.Path(@"c:\temp\folder\folder"), new MockDirectoryData() },
+                { XFS.Path(@"c:\temp\folder\older"), new MockDirectoryData() }
+            });
+
+            var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
+            var result = directoryInfo.EnumerateFileSystemInfos("f*", SearchOption.AllDirectories).ToArray();
+
+            Assert.That(result.Length, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void MockDirectoryInfo_GetParent_ShouldReturnDirectoriesAndNamesWithSearchPattern()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\a\b\c"));
+            var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\a\b\c"));
+
+            // Act
+            var result = directoryInfo.Parent;
+
+            // Assert
+            Assert.AreEqual(XFS.Path(@"c:\a\b"), result.FullName);
+        }
+
+        [Test]
+        public void MockDirectoryInfo_EnumerateFiles_ShouldReturnAllFiles()
+        {
+          // Arrange
+          var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                //Files "above" in folder we're querying
+                { XFS.Path(@"c:\temp\a.txt"), "" },
+
+                //Files in the folder we're querying
+                { XFS.Path(@"c:\temp\folder\b.txt"), "" },
+                { XFS.Path(@"c:\temp\folder\c.txt"), "" },
+
+                //Files "below" the folder we're querying
+                { XFS.Path(@"c:\temp\folder\deeper\d.txt"), "" }
+            });
+
+          // Act
+          var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
+
+          // Assert
+          Assert.AreEqual(new[]{"b.txt", "c.txt"}, directoryInfo.EnumerateFiles().ToList().Select(x => x.Name).ToArray());
+        }
+
+        [Test]
+        public void MockDirectoryInfo_EnumerateDirectories_ShouldReturnAllDirectories()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                //A file we want to ignore entirely
+                { XFS.Path(@"c:\temp\folder\a.txt"), "" },
+
+                //Some files in sub folders (which we also want to ignore entirely)
+                { XFS.Path(@"c:\temp\folder\b\file.txt"), "" },
+                { XFS.Path(@"c:\temp\folder\c\other.txt"), "" },
+            });
+            var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
+
+            // Act
+            var directories = directoryInfo.EnumerateDirectories().Select(a => a.Name).ToArray();
+
+            // Assert
+            Assert.AreEqual(new[] { "b", "c" }, directories);
+        }
+
+        [TestCase(@"\\unc\folder", @"\\unc\folder")]
+        [TestCase(@"\\unc/folder\\foo", @"\\unc\folder\foo")]
+        [WindowsOnly(WindowsSpecifics.UNCPaths)]
+        public void MockDirectoryInfo_FullName_ShouldReturnNormalizedUNCPath(string directoryPath, string expectedFullName)
+        {
+            // Arrange
+            directoryPath = XFS.Path(directoryPath);
+            expectedFullName = XFS.Path(expectedFullName);
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var directoryInfo = new MockDirectoryInfo(fileSystem, directoryPath);
+
+            // Act
+            var actualFullName = directoryInfo.FullName;
+
+            // Assert
+            Assert.AreEqual(expectedFullName, actualFullName);
+        }
+
+        [TestCase(@"c:\temp\\folder", @"c:\temp\folder")]
+        [TestCase(@"c:\temp//folder", @"c:\temp\folder")]
+        [TestCase(@"c:\temp//\\///folder", @"c:\temp\folder")]
+        public void MockDirectoryInfo_FullName_ShouldReturnNormalizedPath(string directoryPath, string expectedFullName)
+        {
+            // Arrange
+            directoryPath = XFS.Path(directoryPath);
+            expectedFullName = XFS.Path(expectedFullName);
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var directoryInfo = new MockDirectoryInfo(fileSystem, directoryPath);
+
+            // Act
+            var actualFullName = directoryInfo.FullName;
+
+            // Assert
+            Assert.AreEqual(expectedFullName, actualFullName);
+        }
+
+        [Test]
+        public void MockDirectoryInfo_Constructor_ShouldThrowArgumentNullException_IfArgumentDirectoryIsNull()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+           TestDelegate action = () => new MockDirectoryInfo(fileSystem, null);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentNullException>(action);
+            Assert.That(exception.Message, Does.StartWith("Value cannot be null."));
+        }
+
+        [Test]
+        public void MockDirectoryInfo_Constructor_ShouldThrowArgumentNullException_IfArgumentFileSystemIsNull()
+        {
+            // Arrange
+            // nothing to do
+
+            // Act
+            TestDelegate action = () => new MockDirectoryInfo(null, XFS.Path(@"c:\foo\bar\folder"));
+
+            // Assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Test]
+        public void MockDirectoryInfo_Constructor_ShouldThrowArgumentException_IfArgumentDirectoryIsEmpty()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => new MockDirectoryInfo(fileSystem, string.Empty);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.Message, Does.StartWith("The path is not of a legal form."));
+        }
+
+        [Test]
+        public void MockDirectoryInfo_ToString_ShouldReturnDirectoryName()
+        {
+            var directoryPath = XFS.Path(@"c:\temp\folder\folder");
+
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var directoryInfo = new MockDirectoryInfo(fileSystem, directoryPath);
+
+            // Act
+            var str = directoryInfo.ToString();
+
+            // Assert
+            Assert.AreEqual(directoryPath, str);
+        }
+    }
+}

--- a/tests/MockDirectorySetAccessControlTests.cs
+++ b/tests/MockDirectorySetAccessControlTests.cs
@@ -1,0 +1,69 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using Security.AccessControl;
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    [WindowsOnly(WindowsSpecifics.AccessControlLists)]
+    public class MockDirectorySetAccessControlTests
+    {
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockDirectory_SetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var directorySecurity = new DirectorySecurity();
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.SetAccessControl(path, directorySecurity);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockDirectory_SetAccessControl_ShouldThrowDirectoryNotFoundExceptionIfDirectoryDoesNotExistInMockData()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var expectedFileName = XFS.Path(@"c:\a\");
+            var directorySecurity = new DirectorySecurity();
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.SetAccessControl(expectedFileName, directorySecurity);
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockDirectory_SetAccessControl_ShouldSetAccessControlOfDirectoryData()
+        {
+            // Arrange
+            var filePath = XFS.Path(@"c:\a\");
+            var fileData = new MockDirectoryData();
+
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { filePath, fileData }
+            });
+
+            // Act
+            var expectedAccessControl = new DirectorySecurity();
+            expectedAccessControl.SetAccessRuleProtection(false, false);
+            fileSystem.Directory.SetAccessControl(filePath, expectedAccessControl);
+
+            // Assert
+            var accessControl = fileSystem.Directory.GetAccessControl(filePath);
+            Assert.That(accessControl, Is.EqualTo(expectedAccessControl));
+        }
+    }
+}

--- a/tests/MockDirectoryTests.cs
+++ b/tests/MockDirectoryTests.cs
@@ -1,0 +1,1541 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Security.AccessControl;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    public class MockDirectoryTests
+    {
+        [Test]
+        public void MockDirectory_GetFiles_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndSearchOptionIsAllDirectories()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            var expected = new[]
+            {
+                XFS.Path(@"c:\a\a.txt"),
+                XFS.Path(@"c:\a\b.gif"),
+                XFS.Path(@"c:\a\c.txt"),
+                XFS.Path(@"c:\a\a\a.txt"),
+                XFS.Path(@"c:\a\a\b.txt"),
+                XFS.Path(@"c:\a\a\c.gif")
+            };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "*", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        private MockFileSystem SetupFileSystem()
+        {
+            return new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.gif"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\b.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\c.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\b.gif"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\c.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\a.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\b.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\c.gif"), new MockFileData("Demo text content") },
+            });
+
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldReturnFilesDirectlyBelowPathWhenPatternIsWildcardAndSearchOptionIsTopDirectoryOnly()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            var expected = new[]
+            {
+                XFS.Path(@"c:\a\a.txt"),
+                XFS.Path(@"c:\a\b.gif"),
+                XFS.Path(@"c:\a\c.txt")
+            };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "*", SearchOption.TopDirectoryOnly);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPattern()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            var expected = new[]
+            {
+                XFS.Path(@"c:\a.gif"),
+                XFS.Path(@"c:\a\b.gif"),
+                XFS.Path(@"c:\a\a\c.gif")
+            };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternWithThreeCharacterLongFileExtension_RepectingAllDirectorySearchOption()
+        {
+            // Arrange
+            var additionalFilePath = XFS.Path(@"c:\a\a\c.gifx");
+            var fileSystem = SetupFileSystem();
+            fileSystem.AddFile(additionalFilePath, new MockFileData(string.Empty));
+            fileSystem.AddFile(XFS.Path(@"c:\a\a\c.gifx.xyz"), new MockFileData(string.Empty));
+            fileSystem.AddFile(XFS.Path(@"c:\a\a\c.gifz\xyz"), new MockFileData(string.Empty));
+            var expected = new[]
+                {
+                    XFS.Path(@"c:\a.gif"),
+                    XFS.Path(@"c:\a\b.gif"),
+                    XFS.Path(@"c:\a\a\c.gif"),
+                    additionalFilePath
+                };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternWithThreeCharacterLongFileExtension_RepectingTopDirectorySearchOption()
+        {
+            // Arrange
+            var additionalFilePath = XFS.Path(@"c:\a\c.gifx");
+            var fileSystem = SetupFileSystem();
+            fileSystem.AddFile(additionalFilePath, new MockFileData(string.Empty));
+            fileSystem.AddFile(XFS.Path(@"c:\a\a\c.gifx.xyz"), new MockFileData(string.Empty));
+            fileSystem.AddFile(XFS.Path(@"c:\a\a\c.gifx"), new MockFileData(string.Empty));
+            var expected = new[]
+                {
+                    XFS.Path(@"c:\a\b.gif"),
+                    additionalFilePath
+                };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "*.gif", SearchOption.TopDirectoryOnly);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternOnlyIfTheFileExtensionIsThreeCharacterLong()
+        {
+            // Arrange
+            var additionalFilePath = XFS.Path(@"c:\a\c.gi");
+            var fileSystem = SetupFileSystem();
+            fileSystem.AddFile(additionalFilePath, new MockFileData(string.Empty));
+            fileSystem.AddFile(XFS.Path(@"c:\a\a\c.gifx.xyz"), new MockFileData(string.Empty));
+            fileSystem.AddFile(XFS.Path(@"c:\a\a\c.gif"), new MockFileData(string.Empty));
+            fileSystem.AddFile(XFS.Path(@"c:\a\a\c.gifx"), new MockFileData(string.Empty));
+            var expected = new[]
+                {
+                    additionalFilePath
+                };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "*.gi", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternWithDotsInFilenames()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.there.are.dots.in.this.filename.gif"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\b.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\c.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\b.gif"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\c.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\a.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\b.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\c.gif"), new MockFileData("Demo text content") },
+            });
+            var expected = new[]
+            {
+                XFS.Path(@"c:\a.there.are.dots.in.this.filename.gif"),
+                XFS.Path(@"c:\a\b.gif"),
+                XFS.Path(@"c:\a\a\c.gif")
+            };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo( expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_FilterShouldFindFilesWithSpecialChars()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.1#.pdf"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\b\b #1.txt"), new MockFileData("Demo text content") }
+            });
+            var expected = new[]
+            {
+                XFS.Path(@"c:\a.1#.pdf"),
+                XFS.Path(@"c:\b\b #1.txt")
+            };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.*", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternAndSearchOptionTopDirectoryOnly()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            var expected = new[] { XFS.Path(@"c:\a.gif") };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.TopDirectoryOnly);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        private void ExecuteTimeAttributeTest(Action<IFileSystem, string, DateTime> setter, Func<IFileSystem, string, DateTime> getter)
+        {
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("Demo text content") }
+            });
+
+            // Act
+            var time = new DateTime(2010, 6, 4, 13, 26, 42);
+            setter(fileSystem, path, time);
+            var result = getter(fileSystem, path);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(time));
+        }
+
+        [Test]
+        public void MockDirectory_GetCreationTime_ShouldReturnCreationTimeFromFile()
+        {
+            ExecuteTimeAttributeTest(
+                (fs, p, d) => fs.File.SetCreationTime(p, d),
+                (fs, p) => fs.Directory.GetCreationTime(p));
+        }
+
+        [Test]
+        public void MockDirectory_GetCreationTimeUtc_ShouldReturnCreationTimeUtcFromFile()
+        {
+            ExecuteTimeAttributeTest(
+                (fs, p, d) => fs.File.SetCreationTimeUtc(p, d),
+                (fs, p) => fs.Directory.GetCreationTimeUtc(p));
+        }
+
+        [Test]
+        public void MockDirectory_GetLastAccessTime_ShouldReturnLastAccessTimeFromFile()
+        {
+            ExecuteTimeAttributeTest(
+                (fs, p, d) => fs.File.SetLastAccessTime(p, d),
+                (fs, p) => fs.Directory.GetLastAccessTime(p));
+        }
+
+        [Test]
+        public void MockDirectory_GetLastAccessTimeUtc_ShouldReturnLastAccessTimeUtcFromFile()
+        {
+            ExecuteTimeAttributeTest(
+                (fs, p, d) => fs.File.SetLastAccessTimeUtc(p, d),
+                (fs, p) => fs.Directory.GetLastAccessTimeUtc(p));
+        }
+
+        [Test]
+        public void MockDirectory_GetLastWriteTime_ShouldReturnLastWriteTimeFromFile()
+        {
+            ExecuteTimeAttributeTest(
+                (fs, p, d) => fs.File.SetLastWriteTime(p, d),
+                (fs, p) => fs.Directory.GetLastWriteTime(p));
+        }
+
+        [Test]
+        public void MockDirectory_GetLastWriteTimeUtc_ShouldReturnLastWriteTimeUtcFromFile()
+        {
+            ExecuteTimeAttributeTest(
+                (fs, p, d) => fs.File.SetLastWriteTimeUtc(p, d),
+                (fs, p) => fs.Directory.GetLastWriteTimeUtc(p));
+        }
+
+        [Test]
+        public void MockDirectory_SetCreationTime_ShouldSetCreationTimeOnFile()
+        {
+            ExecuteTimeAttributeTest(
+                (fs, p, d) => fs.Directory.SetCreationTime(p, d),
+                (fs, p) => fs.File.GetCreationTime(p));
+        }
+
+        [Test]
+        public void MockDirectory_SetCreationTimeUtc_ShouldSetCreationTimeUtcOnFile()
+        {
+            ExecuteTimeAttributeTest(
+                (fs, p, d) => fs.Directory.SetCreationTimeUtc(p, d),
+                (fs, p) => fs.File.GetCreationTimeUtc(p));
+        }
+
+        [Test]
+        public void MockDirectory_SetLastAccessTime_ShouldSetLastAccessTimeOnFile()
+        {
+            ExecuteTimeAttributeTest(
+                (fs, p, d) => fs.Directory.SetLastAccessTime(p, d),
+                (fs, p) => fs.File.GetLastAccessTime(p));
+        }
+
+        [Test]
+        public void MockDirectory_SetLastAccessTimeUtc_ShouldSetLastAccessTimeUtcOnFile()
+        {
+            ExecuteTimeAttributeTest(
+                (fs, p, d) => fs.Directory.SetLastAccessTimeUtc(p, d),
+                (fs, p) => fs.File.GetLastAccessTimeUtc(p));
+        }
+
+        [Test]
+        public void MockDirectory_SetLastWriteTime_ShouldSetLastWriteTimeOnFile()
+        {
+            ExecuteTimeAttributeTest(
+                (fs, p, d) => fs.Directory.SetLastWriteTime(p, d),
+                (fs, p) => fs.File.GetLastWriteTime(p));
+        }
+
+        [Test]
+        public void MockDirectory_SetLastWriteTimeUtc_ShouldSetLastWriteTimeUtcOnFile()
+        {
+            ExecuteTimeAttributeTest(
+                (fs, p, d) => fs.Directory.SetLastWriteTimeUtc(p, d),
+                (fs, p) => fs.File.GetLastWriteTimeUtc(p));
+        }
+
+        [Test]
+        public void MockDirectory_Exists_ShouldReturnTrueForDirectoryDefinedInMemoryFileSystemWithoutTrailingSlash()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content") }
+            });
+
+            // Act
+            var result = fileSystem.Directory.Exists(XFS.Path(@"c:\foo"));
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void MockDirectory_Exists_ShouldReturnTrueForDirectoryDefinedInMemoryFileSystemWithTrailingSlash()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content") }
+            });
+
+            // Act
+            var result = fileSystem.Directory.Exists(XFS.Path(@"c:\foo\"));
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void MockDirectory_Exists_ShouldReturnFalseForDirectoryNotDefinedInMemoryFileSystemWithoutTrailingSlash()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content") }
+            });
+
+            // Act
+            var result = fileSystem.Directory.Exists(XFS.Path(@"c:\baz"));
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void MockDirectory_Exists_ShouldReturnFalseForDirectoryNotDefinedInMemoryFileSystemWithTrailingSlash()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content") }
+            });
+
+            // Act
+            var result = fileSystem.Directory.Exists(XFS.Path(@"c:\baz\"));
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void MockDirectory_Exists_ShouldReturnFalseForDirectoryNotDefinedInMemoryFileSystemWithSimilarFileName()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\baz.txt"), new MockFileData("Demo text content") }
+            });
+
+            // Act
+            var result = fileSystem.Directory.Exists(XFS.Path(@"c:\baz"));
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void MockDirectory_Exists_ShouldReturnTrueForDirectoryCreatedViaMocks()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content") }
+            });
+            fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\bar"));
+
+            // Act
+            var result = fileSystem.Directory.Exists(XFS.Path(@"c:\bar"));
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void MockDirectory_Exists_ShouldReturnTrueForFolderContainingFileAddedToMockFileSystem()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content"));
+
+            // Act
+            var result = fileSystem.Directory.Exists(XFS.Path(@"c:\foo\"));
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [TestCase(@"\\s")]
+        [TestCase(@"<")]
+        [TestCase("\t")]
+        public void MockDirectory_Exists_ShouldReturnFalseForIllegalPath(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            var result = fileSystem.Directory.Exists(path);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void MockDirectory_Exists_ShouldReturnFalseForFiles()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content"));
+
+            // Act
+            var result = fileSystem.Directory.Exists(XFS.Path(@"c:\foo\bar.txt"));
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void MockDirectory_CreateDirectory_ShouldCreateFolderInMemoryFileSystem()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo.txt"), new MockFileData("Demo text content") }
+            });
+
+            // Act
+            fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\bar"));
+
+            // Assert
+            Assert.IsTrue(fileSystem.FileExists(XFS.Path(@"c:\bar\")));
+            Assert.IsTrue(fileSystem.AllDirectories.Any(d => d == XFS.Path(@"c:\bar")));
+        }
+
+        // Issue #210
+        [Test]
+        public void MockDirectory_CreateDirectory_ShouldIgnoreExistingDirectoryRegardlessOfTrailingSlash()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo\"), new MockDirectoryData() }
+            });
+
+            // Act/Assert
+            Assert.That(() => fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo")), Throws.Nothing);
+            Assert.That(() => fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo\")), Throws.Nothing);
+        }
+
+        [Test]
+        public void MockDirectory_CreateDirectory_ShouldReturnDirectoryInfoBase()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo.txt"), new MockFileData("Demo text content") }
+            });
+
+            // Act
+            var result = fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\bar"));
+
+            // Assert
+            Assert.IsNotNull(result);
+        }
+
+        [Test]
+        public void MockDirectory_CreMockDirectory_CreateDirectory_ShouldReturnDirectoryInfoBaseWhenDirectoryExists()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo\"), new MockDirectoryData() }
+            });
+
+            // Act
+            var result = fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo\"));
+
+            // Assert
+            Assert.IsNotNull(result);
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.UNCPaths)]
+        public void MockDirectory_CreateDirectory_ShouldWorkWithUNCPath()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            fileSystem.Directory.CreateDirectory(XFS.Path(@"\\server\share\path\to\create", () => false));
+
+            // Assert
+            Assert.IsTrue(fileSystem.Directory.Exists(XFS.Path(@"\\server\share\path\to\create\", () => false)));
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.UNCPaths)]
+        public void MockDirectory_CreateDirectory_ShouldFailIfTryingToCreateUNCPathOnlyServer()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            var ex = Assert.Throws<ArgumentException>(() => fileSystem.Directory.CreateDirectory(XFS.Path(@"\\server", () => false)));
+
+            // Assert
+            StringAssert.StartsWith("The UNC path should be of the form \\\\server\\share.", ex.Message);
+            Assert.That(ex.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.UNCPaths)]
+        public void MockDirectory_CreateDirectory_ShouldSucceedIfTryingToCreateUNCPathShare()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            fileSystem.Directory.CreateDirectory(XFS.Path(@"\\server\share", () => false));
+
+            // Assert
+            Assert.IsTrue(fileSystem.Directory.Exists(XFS.Path(@"\\server\share\", () => false)));
+        }
+
+        [Test]
+        public void MockDirectory_Delete_ShouldDeleteDirectory()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\bar\foo.txt"), new MockFileData("Demo text content") }
+            });
+
+            // Act
+            fileSystem.Directory.Delete(XFS.Path(@"c:\bar"), true);
+
+            // Assert
+            Assert.IsFalse(fileSystem.Directory.Exists(XFS.Path(@"c:\bar")));
+        }
+
+        [Test]
+        public void MockDirectory_Delete_ShouldDeleteDirectoryCaseInsensitively()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\bar\foo.txt"), new MockFileData("Demo text content") }
+            });
+
+            // Act
+            fileSystem.Directory.Delete(XFS.Path(@"c:\BAR"), true);
+
+            // Assert
+            Assert.IsFalse(fileSystem.Directory.Exists(XFS.Path(@"c:\bar")));
+        }
+
+        [Test]
+        public void MockDirectory_Delete_ShouldThrowDirectoryNotFoundException()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\bar\foo.txt"), new MockFileData("Demo text content") }
+            });
+
+            var ex = Assert.Throws<DirectoryNotFoundException>(() => fileSystem.Directory.Delete(XFS.Path(@"c:\baz")));
+
+            Assert.That(ex.Message, Is.EqualTo(XFS.Path("c:\\baz") + " does not exist or could not be found."));
+        }
+
+        [Test]
+        public void MockDirectory_Delete_ShouldThrowIOException()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\bar\foo.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\bar\baz.txt"), new MockFileData("Demo text content") }
+            });
+
+            var ex = Assert.Throws<IOException>(() => fileSystem.Directory.Delete(XFS.Path(@"c:\bar")));
+
+            Assert.That(ex.Message, Is.EqualTo("The directory specified by " + XFS.Path("c:\\bar") + " is read-only, or recursive is false and " + XFS.Path("c:\\bar") + " is not an empty directory."));
+        }
+
+        [Test]
+        public void MockDirectory_Delete_ShouldDeleteDirectoryRecursively()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\bar\foo.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\bar\bar2\foo.txt"), new MockFileData("Demo text content") }
+            });
+
+            // Act
+            fileSystem.DirectoryInfo.FromDirectoryName(XFS.Path(@"c:\bar")).Delete(true);
+
+            // Assert
+            Assert.IsFalse(fileSystem.Directory.Exists(XFS.Path(@"c:\bar")));
+            Assert.IsFalse(fileSystem.Directory.Exists(XFS.Path(@"c:\bar\bar2")));
+        }
+
+        [Test]
+        public void MockDirectory_GetFileSystemEntries_Returns_Files_And_Directories()
+        {
+            string testPath = XFS.Path(@"c:\foo\bar.txt");
+            string testDir =  XFS.Path(@"c:\foo\bar");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { testPath, new MockFileData("Demo text content") },
+                { testDir,  new MockDirectoryData() }
+            });
+
+            var entries = fileSystem.Directory.GetFileSystemEntries(XFS.Path(@"c:\foo")).OrderBy(k => k);
+            Assert.AreEqual(2, entries.Count());
+            Assert.AreEqual(testDir, entries.First());
+            Assert.AreEqual(testPath, entries.Last());
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldThrowArgumentNullException_IfPathParamIsNull()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+
+            TestDelegate action = () => fileSystem.Directory.GetFiles(null);
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldThrowDirectoryNotFoundException_IfPathDoesNotExists()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.GetFiles(XFS.Path(@"c:\Foo"), "*a.txt");
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_Returns_Files()
+        {
+            string testPath = XFS.Path(@"c:\foo\bar.txt");
+            string testDir = XFS.Path(@"c:\foo\bar\");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { testPath, new MockFileData("Demo text content") },
+                { testDir,  new MockDirectoryData() }
+            });
+
+            var entries = fileSystem.Directory.GetFiles(XFS.Path(@"c:\foo")).OrderBy(k => k);
+            Assert.AreEqual(1, entries.Count());
+            Assert.AreEqual(testPath, entries.First());
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldThrowAnArgumentNullException_IfSearchPatternIsNull()
+        {
+            // Arrange
+            var directoryPath = XFS.Path(@"c:\Foo");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(directoryPath);
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.GetFiles(directoryPath, null);
+
+            // Assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldThrowAnArgumentException_IfSearchPatternEndsWithTwoDots()
+        {
+            // Arrange
+            var directoryPath = XFS.Path(@"c:\Foo");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(directoryPath);
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.GetFiles(directoryPath, "*a..");
+
+            // Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [TestCase(@"..\")]
+        [TestCase(@"aaa\vv..\")]
+        [TestCase(@"a..\b")]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+        public void MockDirectory_GetFiles_ShouldThrowAnArgumentException_IfSearchPatternContainsTwoDotsFollowedByOneBackslash(string searchPattern)
+        {
+            // Arrange
+            var directoryPath = XFS.Path(@"c:\Foo");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(directoryPath);
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.GetFiles(directoryPath, searchPattern);
+
+            // Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [TestCase(@"a../b")]
+        [TestCase(@"../")]
+        public void MockDirectory_GetFiles_ShouldThrowAnArgumentException_IfSearchPatternContainsTwoDotsFollowedByOneSlash(string searchPattern)
+        {
+            // Arrange
+            var directoryPath = XFS.Path(@"c:\Foo");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(directoryPath);
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.GetFiles(directoryPath, searchPattern);
+
+            // Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
+        public void MockDirectory_GetFiles_ShouldFindFilesContainingTwoOrMoreDots()
+        {
+            // Arrange
+            string testPath = XFS.Path(@"c:\foo..r\bar.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+                {
+                    { testPath, new MockFileData(string.Empty) }
+                });
+
+            // Act
+            var actualResult = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), XFS.Path(@"foo..r\*"));
+
+            // Assert
+            Assert.That(actualResult, Is.EquivalentTo(new [] { testPath }));
+        }
+
+#if NET40
+        [TestCase(@"""")]
+#endif
+        [TestCase("aa\t")]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+        public void MockDirectory_GetFiles_ShouldThrowAnArgumentException_IfSearchPatternHasIllegalCharacters(string searchPattern)
+        {
+            // Arrange
+            var directoryPath = XFS.Path(@"c:\Foo");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(directoryPath);
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.GetFiles(directoryPath, searchPattern);
+
+            // Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
+        public void MockDirectory_GetRoot_Returns_Root()
+        {
+            string testDir = XFS.Path(@"c:\foo\bar\");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { testDir,  new MockDirectoryData() }
+            });
+
+            Assert.AreEqual(XFS.Path("C:\\"), fileSystem.Directory.GetDirectoryRoot(XFS.Path(@"C:\foo\bar")));
+        }
+
+#if NET40
+        [Test]
+        public void MockDirectory_GetLogicalDrives_Returns_LogicalDrives()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+                {
+                    {XFS.Path(@"c:\foo\bar\"), new MockDirectoryData()},
+                    {XFS.Path(@"c:\foo\baz\"), new MockDirectoryData()},
+                    {XFS.Path(@"d:\bash\"), new MockDirectoryData()},
+                });
+
+            var drives = fileSystem.Directory.GetLogicalDrives();
+
+            if (XFS.IsUnixPlatform())
+            {
+                Assert.AreEqual(1, drives.Length);
+                Assert.IsTrue(drives.Contains("/"));
+            }
+            else
+            {
+                Assert.AreEqual(2, drives.Length);
+                Assert.IsTrue(drives.Contains("c:\\"));
+                Assert.IsTrue(drives.Contains("d:\\"));
+            }
+        }
+#endif
+
+        [Test]
+        public void MockDirectory_GetDirectories_Returns_Child_Directories()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"A:\folder1\folder2\folder3\file.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"A:\folder1\folder4\file2.txt"), new MockFileData("Demo text content 2") },
+            });
+
+            var directories = fileSystem.Directory.GetDirectories(XFS.Path(@"A:\folder1")).ToArray();
+
+            //Check that it does not returns itself
+            Assert.IsFalse(directories.Contains(XFS.Path(@"A:\folder1")));
+
+            //Check that it correctly returns all child directories
+            Assert.AreEqual(2, directories.Count());
+            Assert.IsTrue(directories.Contains(XFS.Path(@"A:\folder1\folder2")));
+            Assert.IsTrue(directories.Contains(XFS.Path(@"A:\folder1\folder4")));
+        }
+
+        [Test]
+        public void MockDirectory_GetDirectories_WithTopDirectories_ShouldOnlyReturnTopDirectories()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\.foo\"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\foo"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\foo.foo"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\.foo\.foo"));
+            fileSystem.AddFile(XFS.Path(@"C:\Folder\.foo\bar"), new MockFileData(string.Empty));
+
+            // Act
+            var actualResult = fileSystem.Directory.GetDirectories(XFS.Path(@"c:\Folder\"), "*.foo");
+
+            // Assert
+            Assert.That(actualResult, Is.EquivalentTo(new []{XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo")}));
+        }
+
+        [Test]
+        public void MockDirectory_GetDirectories_RelativeWithNoSubDirectories_ShouldReturnDirectories()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory("Folder");
+
+            // Act
+            var actualResult = fileSystem.Directory.GetDirectories("Folder");
+
+            // Assert
+            Assert.That(actualResult, Is.Empty);
+        }
+
+        [TestCase(@"Folder\SubFolder")]
+        [TestCase(@"Folder")]
+        public void MockDirectory_GetDirectories_RelativeDirectory_WithoutChildren_ShouldReturnNoChildDirectories(string relativeDirPath)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(relativeDirPath);
+
+            // Act
+            var actualResult = fileSystem.Directory.GetDirectories(relativeDirPath);
+
+            // Assert
+            Assert.That(actualResult, Is.Empty);
+        }
+
+        [TestCase(@"Folder\SubFolder")]
+        [TestCase(@"Folder")]
+        public void MockDirectory_GetDirectories_RelativeDirectory_WithChildren_ShouldReturnChildDirectories(string relativeDirPath)
+        {
+            // Arrange
+            var currentDirectory = XFS.Path(@"T:\foo");
+            var fileSystem = new MockFileSystem(null, currentDirectory: currentDirectory);
+            fileSystem.Directory.CreateDirectory(XFS.Path(relativeDirPath));
+            fileSystem.Directory.CreateDirectory(XFS.Path(relativeDirPath + @"\child"));
+
+            // Act
+            var actualResult = fileSystem.Directory.GetDirectories(XFS.Path(relativeDirPath));
+
+            // Assert
+            CollectionAssert.AreEqual(
+                new[] { XFS.Path(currentDirectory + @"\" + relativeDirPath + @"\child") },
+                actualResult
+            );
+        }
+
+        [Test]
+        public void MockDirectory_GetDirectories_AbsoluteWithNoSubDirectories_ShouldReturnDirectories()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory("Folder");
+
+            // Act
+            var fullPath = fileSystem.Path.GetFullPath("Folder");
+            var actualResult = fileSystem.Directory.GetDirectories(fullPath);
+
+            // Assert
+            Assert.That(actualResult, Is.Empty);
+        }
+
+        [Test]
+        public void MockDirectory_GetDirectories_WithAllDirectories_ShouldReturnsAllMatchingSubFolders()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\.foo\"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\foo"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\foo.foo"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\.foo\.foo"));
+            fileSystem.AddFile(XFS.Path(@"C:\Folder\.foo\bar"), new MockFileData(string.Empty));
+
+            // Act
+            var actualResult = fileSystem.Directory.GetDirectories(XFS.Path(@"c:\Folder\"), "*.foo", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(actualResult, Is.EquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo"), XFS.Path(@"C:\Folder\.foo\.foo") }));
+        }
+
+        [Test]
+        public void MockDirectory_GetDirectories_ShouldThrowWhenPathIsNotMocked()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.gif"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\b.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\c.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\b.gif"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\c.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\a.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\b.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\c.gif"), new MockFileData("Demo text content") },
+            });
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.GetDirectories(XFS.Path(@"c:\d"));
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockDirectory_EnumerateDirectories_Returns_Child_Directories()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"A:\folder1\folder2\folder3\file.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"A:\folder1\folder4\file2.txt"), new MockFileData("Demo text content 2") },
+            });
+
+            var directories = fileSystem.Directory.EnumerateDirectories(XFS.Path(@"A:\folder1")).ToArray();
+
+            //Check that it does not returns itself
+            Assert.IsFalse(directories.Contains(XFS.Path(@"A:\folder1")));
+
+            //Check that it correctly returns all child directories
+            Assert.AreEqual(2, directories.Count());
+            Assert.IsTrue(directories.Contains(XFS.Path(@"A:\folder1\folder2")));
+            Assert.IsTrue(directories.Contains(XFS.Path(@"A:\folder1\folder4")));
+        }
+
+        [Test]
+        public void MockDirectory_EnumerateDirectories_WithTopDirectories_ShouldOnlyReturnTopDirectories()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\.foo\"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\foo"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\foo.foo"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\.foo\.foo"));
+            fileSystem.AddFile(XFS.Path(@"C:\Folder\.foo\bar"), new MockFileData(string.Empty));
+
+            // Act
+            var actualResult = fileSystem.Directory.EnumerateDirectories(XFS.Path(@"c:\Folder\"), "*.foo");
+
+            // Assert
+            Assert.That(actualResult, Is.EquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo") }));
+        }
+
+        [Test]
+        public void MockDirectory_EnumerateDirectories_WithAllDirectories_ShouldReturnsAllMatchingSubFolders()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\.foo\"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\foo"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\foo.foo"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\Folder\.foo\.foo"));
+            fileSystem.AddFile(XFS.Path(@"C:\Folder\.foo\bar"), new MockFileData(string.Empty));
+
+            // Act
+            var actualResult = fileSystem.Directory.EnumerateDirectories(XFS.Path(@"c:\Folder\"), "*.foo", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(actualResult, Is.EquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo"), XFS.Path(@"C:\Folder\.foo\.foo") }));
+        }
+
+        [Test]
+        public void MockDirectory_EnumerateDirectories_ShouldThrowWhenPathIsNotMocked()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.gif"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\b.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\c.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\b.gif"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\c.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\a.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\b.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\a\c.gif"), new MockFileData("Demo text content") },
+            });
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.EnumerateDirectories(XFS.Path(@"c:\d"));
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(action);
+        }
+
+        public static IEnumerable<object[]> GetPathsForMoving()
+        {
+            yield return new object[] { XFS.Path(@"a:\folder1\"), XFS.Path(@"A:\folder3\"), XFS.Path("file.txt"), XFS.Path(@"folder2\file2.txt") };
+            yield return new object[] { XFS.Path(@"A:\folder1\"), XFS.Path(@"A:\folder3\"), XFS.Path("file.txt"), XFS.Path(@"folder2\file2.txt") };
+            yield return new object[] { XFS.Path(@"a:\folder1\"), XFS.Path(@"a:\folder3\"), XFS.Path("file.txt"), XFS.Path(@"folder2\file2.txt") };
+            yield return new object[] { XFS.Path(@"A:\folder1\"), XFS.Path(@"a:\folder3\"), XFS.Path("file.txt"), XFS.Path(@"folder2\file2.txt") };
+            yield return new object[] { XFS.Path(@"A:\folder1\"), XFS.Path(@"a:\folder3\"), XFS.Path("file.txt"), XFS.Path(@"Folder2\file2.txt") };
+            yield return new object[] { XFS.Path(@"A:\folder1\"), XFS.Path(@"a:\folder3\"), XFS.Path("file.txt"), XFS.Path(@"Folder2\fiLe2.txt") };
+            yield return new object[] { XFS.Path(@"A:\folder1\"), XFS.Path(@"a:\folder3\"), XFS.Path("folder444\\file.txt"), XFS.Path(@"Folder2\fiLe2.txt") };
+        }
+
+        [Test]
+        public void Move_DirectoryExistsWithDifferentCase_DirectorySuccessfullyMoved()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\OLD_LOCATION\Data"));
+            fileSystem.AddFile(XFS.Path(@"C:\old_location\Data\someFile.txt"), new MockFileData("abc"));
+
+            // Act
+            fileSystem.Directory.Move(XFS.Path(@"C:\old_location"), XFS.Path(@"C:\NewLocation\"));
+
+            // Assert
+            Assert.IsTrue(fileSystem.File.Exists(XFS.Path(@"C:\NewLocation\Data\someFile.txt")));
+        }
+
+        [TestCaseSource("GetPathsForMoving")]
+        public void MockDirectory_Move_ShouldMove(string sourceDirName, string destDirName, string filePathOne, string filePathTwo)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(sourceDirName + filePathOne) , new MockFileData("aaa") },
+                { XFS.Path(sourceDirName + filePathTwo) , new MockFileData("bbb") },
+            });
+
+            // Act
+            fileSystem.DirectoryInfo.FromDirectoryName(sourceDirName).MoveTo(destDirName);
+
+            // Assert
+            Assert.IsFalse(fileSystem.Directory.Exists(sourceDirName));
+            Assert.IsTrue(fileSystem.File.Exists(XFS.Path(destDirName + filePathOne)));
+            Assert.IsTrue(fileSystem.File.Exists(XFS.Path(destDirName + filePathTwo)));
+        }
+
+        [Test]
+        public void MockDirectory_Move_ShouldMoveDirectoryAtrributes()
+        {
+            // Arrange
+            var sourceDirName = XFS.Path(@"a:\folder1\");
+            var destDirName = XFS.Path(@"a:\folder2\");
+            const string filePathOne = "file1.txt";
+            const string filePathTwo = "file2.txt";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(sourceDirName + filePathOne) , new MockFileData("aaa") },
+                { XFS.Path(sourceDirName + filePathTwo) , new MockFileData("bbb") },
+            });
+
+            var sourceDirectoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(sourceDirName);
+            sourceDirectoryInfo.Attributes |= FileAttributes.System;
+
+            // Act
+            fileSystem.DirectoryInfo.FromDirectoryName(sourceDirName).MoveTo(destDirName);
+
+            // Assert
+            var destDirectoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(destDirName);
+            Assert.IsTrue(destDirectoryInfo.Attributes.HasFlag(FileAttributes.System));
+        }
+
+        [Test]
+        public void MockDirectory_Move_ShouldMoveDirectoryWithReadOnlySubDirectory()
+        {
+            // Arrange
+            var sourceDirName = XFS.Path(@"a:\folder1\");
+            var sourceSubDirName = XFS.Path(@"a:\folder1\sub\");
+
+            var destDirName = XFS.Path(@"a:\folder2\");
+            var destSubDirName = XFS.Path(@"a:\folder2\sub\");
+
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(sourceSubDirName);
+
+            var subDirectoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(sourceSubDirName);
+            subDirectoryInfo.Attributes |= FileAttributes.ReadOnly;
+
+            var sourceDirectoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(sourceDirName);
+
+            // Act
+            fileSystem.DirectoryInfo.FromDirectoryName(sourceDirName).MoveTo(destDirName);
+
+            // Assert
+            Assert.IsFalse(fileSystem.Directory.Exists(sourceSubDirName));
+            Assert.IsTrue(fileSystem.FileExists(destSubDirName));
+        }
+
+        [Test]
+        public void MockDirectory_GetCurrentDirectory_ShouldReturnValueFromFileSystemConstructor() {
+            string directory = XFS.Path(@"D:\folder1\folder2");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>(), directory);
+
+            var actual = fileSystem.Directory.GetCurrentDirectory();
+
+            Assert.AreEqual(directory, actual);
+        }
+        
+        [Test]
+        public void MockDirectory_GetCurrentDirectory_ShouldReturnDefaultPathWhenNotSet() 
+        {
+            string directory = XFS.Path(@"C:\");
+
+            var fileSystem = new MockFileSystem();
+
+            var actual = fileSystem.Directory.GetCurrentDirectory();
+
+            Assert.AreEqual(directory, actual);
+        }
+
+        [Test]
+        public void MockDirectory_SetCurrentDirectory_ShouldChangeCurrentDirectory() {
+            string directory = XFS.Path(@"D:\folder1\folder2");
+            var fileSystem = new MockFileSystem();
+
+            // Precondition
+            Assert.AreNotEqual(directory, fileSystem.Directory.GetCurrentDirectory());
+
+            fileSystem.Directory.SetCurrentDirectory(directory);
+
+            Assert.AreEqual(directory, fileSystem.Directory.GetCurrentDirectory());
+        }
+
+        [Test]
+        public void MockDirectory_GetParent_ShouldThrowArgumentNullExceptionIfPathIsNull()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate act = () => fileSystem.Directory.GetParent(null);
+
+            // Assert
+            Assert.Throws<ArgumentNullException>(act);
+        }
+
+        [Test]
+        public void MockDirectory_GetParent_ShouldThrowArgumentExceptionIfPathIsEmpty()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate act = () => fileSystem.Directory.GetParent(string.Empty);
+
+            // Assert
+            Assert.Throws<ArgumentException>(act);
+        }
+
+        [Test]
+        public void MockDirectory_GetParent_ShouldReturnADirectoryInfoIfPathDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            var actualResult =  fileSystem.Directory.GetParent(XFS.Path(@"c:\directory\does\not\exist"));
+
+            // Assert
+            Assert.IsNotNull(actualResult);
+        }
+
+        [Test]
+        public void MockDirectory_GetParent_ShouldThrowArgumentExceptionIfPathHasIllegalCharacters()
+        {
+            if (XFS.IsUnixPlatform())
+            {
+                Assert.Pass("Path.GetInvalidChars() does not return anything on Mono");
+                return;
+            }
+
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate act = () => fileSystem.Directory.GetParent(XFS.Path("c:\\director\ty\\has\\illegal\\character"));
+
+            // Assert
+            Assert.Throws<ArgumentException>(act);
+        }
+
+        [Test]
+        public void MockDirectory_GetParent_ShouldReturnNullIfPathIsRoot()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\"));
+
+            // Act
+            var actualResult = fileSystem.Directory.GetParent(XFS.Path(@"c:\"));
+
+            // Assert
+            Assert.IsNull(actualResult);
+        }
+
+        public static IEnumerable<string[]> MockDirectory_GetParent_Cases
+        {
+            get
+            {
+                yield return new [] { XFS.Path(@"c:\a"), XFS.Path(@"c:\") };
+                yield return new [] { XFS.Path(@"c:\a\b\c\d"), XFS.Path(@"c:\a\b\c") };
+                yield return new [] { XFS.Path(@"c:\a\b\c\d\"), XFS.Path(@"c:\a\b\c") };
+            }
+        }
+
+        public void MockDirectory_GetParent_ShouldReturnTheParentWithoutTrailingDirectorySeparatorChar(string path, string expectedResult)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(path);
+
+            // Act
+            var actualResult = fileSystem.Directory.GetParent(path);
+
+            // Assert
+            Assert.AreEqual(expectedResult, actualResult.FullName);
+        }
+
+        [Test]
+        public void MockDirectory_Move_ShouldThrowAnIOExceptionIfBothPathAreIdentical()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\a");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(path);
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.Move(path, path);
+
+            // Assert
+            Assert.Throws<IOException>(action, "Source and destination path must be different.");
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void MockDirectory_Move_ShouldThrowAnIOExceptionIfDirectoriesAreOnDifferentVolumes()
+        {
+            // Arrange
+            string sourcePath = XFS.Path(@"c:\a");
+            string destPath = XFS.Path(@"d:\v");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(sourcePath);
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.Move(sourcePath, destPath);
+
+            // Assert
+            Assert.Throws<IOException>(action, "Source and destination path must have identical roots. Move will not work across volumes.");
+        }
+
+        [Test]
+        public void MockDirectory_Move_ShouldThrowADirectoryNotFoundExceptionIfDesinationDirectoryDoesNotExist()
+        {
+            // Arrange
+            string sourcePath = XFS.Path(@"c:\a");
+            string destPath = XFS.Path(@"c:\b");
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.Move(sourcePath, destPath);
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(action, "Could not find a part of the path 'c:\a'.");
+        }
+
+        [Test]
+        public void MockDirectory_Move_ShouldThrowAnIOExceptionIfDesinationDirectoryExists()
+        {
+            // Arrange
+            string sourcePath = XFS.Path(@"c:\a");
+            string destPath = XFS.Path(@"c:\b");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(sourcePath);
+            fileSystem.AddDirectory(destPath);
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.Move(sourcePath, destPath);
+
+            // Assert
+            Assert.Throws<IOException>(action, "Cannot create 'c:\b\' because a file or directory with the same name already exists.'");
+        }
+
+        [Test]
+        public void MockDirectory_EnumerateFiles_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndSearchOptionIsAllDirectories()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            IEnumerable<string> expected = new[]
+            {
+                XFS.Path(@"c:\a\a.txt"),
+                XFS.Path(@"c:\a\b.gif"),
+                XFS.Path(@"c:\a\c.txt"),
+                XFS.Path(@"c:\a\a\a.txt"),
+                XFS.Path(@"c:\a\a\b.txt"),
+                XFS.Path(@"c:\a\a\c.gif")
+            };
+
+            // Act
+            var result = fileSystem.Directory.EnumerateFiles(XFS.Path(@"c:\a"), "*", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_EnumerateFiles_ShouldFilterByExtensionBasedSearchPattern()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            var expected = new[]
+            {
+                XFS.Path(@"c:\a.gif"),
+                XFS.Path(@"c:\a\b.gif"),
+                XFS.Path(@"c:\a\a\c.gif")
+            };
+
+            // Act
+            var result = fileSystem.Directory.EnumerateFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_EnumerateFiles_WhenFilterIsUnRooted_ShouldFindFilesInCurrentDirectory()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), MockFileData.NullObject },
+                { XFS.Path(@"c:\a\a.txt"), MockFileData.NullObject },
+                { XFS.Path(@"c:\a\b\b.txt"), MockFileData.NullObject },
+                { XFS.Path(@"c:\a\c\c.txt"), MockFileData.NullObject },
+            });
+
+            var expected = new[]
+            {
+                XFS.Path(@"c:\a\b\b.txt"),
+            };
+
+            fileSystem.Directory.SetCurrentDirectory(XFS.Path(@"c:\a"));
+
+            // Act
+            var result = fileSystem.Directory.EnumerateFiles(XFS.Path("b"));
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_EnumerateFiles_WhenFilterIsUnRooted_ShouldNotFindFilesInPathOutsideCurrentDirectory()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), MockFileData.NullObject },
+                { XFS.Path(@"c:\a\b\b.txt"), MockFileData.NullObject },
+                { XFS.Path(@"c:\c\b\b.txt"), MockFileData.NullObject },
+            });
+
+            var expected = new[]
+            {
+                XFS.Path(@"c:\a\b\b.txt"),
+            };
+
+            fileSystem.Directory.SetCurrentDirectory(XFS.Path(@"c:\a"));
+
+            // Act
+            var result = fileSystem.Directory.EnumerateFiles(XFS.Path("b"));
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_EnumerateFileSystemEntries_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndSearchOptionIsAllDirectories()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            IEnumerable<string> expected = new[]
+            {
+                XFS.Path(@"c:\a\a.txt"),
+                XFS.Path(@"c:\a\b.gif"),
+                XFS.Path(@"c:\a\c.txt"),
+                XFS.Path(@"c:\a\a\a.txt"),
+                XFS.Path(@"c:\a\a\b.txt"),
+                XFS.Path(@"c:\a\a\c.gif"),
+                XFS.Path(@"c:\a\a")
+            };
+
+            // Act
+            var result = fileSystem.Directory.EnumerateFileSystemEntries(XFS.Path(@"c:\a"), "*", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_EnumerateFileSystemEntries_ShouldFilterByExtensionBasedSearchPattern()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            var expected = new[]
+            {
+                XFS.Path(@"c:\a.gif"),
+                XFS.Path(@"c:\a\b.gif"),
+                XFS.Path(@"c:\a\a\c.gif")
+            };
+
+            // Act
+            var result = fileSystem.Directory.EnumerateFileSystemEntries(XFS.Path(@"c:\"), "*.gif", SearchOption.AllDirectories);
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void MockDirectory_GetAccessControl_ShouldThrowExceptionOnDirectoryNotFound()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            Assert.Throws<DirectoryNotFoundException>(() => fileSystem.Directory.GetAccessControl(XFS.Path(@"c:\foo")));
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.AccessControlLists)]
+        public void MockDirectory_GetAccessControl_ShouldReturnNewDirectorySecurity()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo\"));
+
+            // Act
+            DirectorySecurity result = fileSystem.Directory.GetAccessControl(XFS.Path(@"c:\foo\"));
+
+            // Assert
+            Assert.That(result, Is.Not.Null);
+        }
+
+        [Test]
+        public void MockDirectory_SetCreationTime_ShouldNotThrowWithoutTrailingBackslash()
+        {
+            var path = XFS.Path(@"C:\NoTrailingBackslash");
+            var fs = new MockFileSystem();
+            fs.Directory.CreateDirectory(path);
+            fs.Directory.SetCreationTime(path, DateTime.Now);
+            fs.Directory.Delete(path);
+        }
+    }
+}

--- a/tests/MockDriveInfoFactoryTests.cs
+++ b/tests/MockDriveInfoFactoryTests.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    [WindowsOnly(WindowsSpecifics.Drives)]
+    public class MockDriveInfoFactoryTests
+    {
+        [Test]
+        public void MockDriveInfoFactory_GetDrives_ShouldReturnDrives()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\Test"));
+            fileSystem.AddDirectory(XFS.Path(@"Z:\Test"));
+            fileSystem.AddDirectory(XFS.Path(@"d:\Test"));
+            var factory = new MockDriveInfoFactory(fileSystem);
+
+            // Act
+            var actualResults = factory.GetDrives();
+
+            var actualNames = actualResults.Select(d => d.Name);
+
+            // Assert
+            Assert.That(actualNames, Is.EquivalentTo(new[] { @"C:\", @"Z:\", @"D:\" }));
+        }
+
+        [Test]
+        public void MockDriveInfoFactory_GetDrives_ShouldReturnDrivesWithNoDuplicates()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\Test"));
+            fileSystem.AddDirectory(XFS.Path(@"c:\Test2"));
+            fileSystem.AddDirectory(XFS.Path(@"Z:\Test"));
+            fileSystem.AddDirectory(XFS.Path(@"d:\Test"));
+            fileSystem.AddDirectory(XFS.Path(@"d:\Test2"));
+            var factory = new MockDriveInfoFactory(fileSystem);
+
+            // Act
+            var actualResults = factory.GetDrives();
+
+            var actualNames = actualResults.Select(d => d.Name);
+
+            // Assert
+            Assert.That(actualNames, Is.EquivalentTo(new[] { @"C:\", @"Z:\", @"D:\" }));
+        }
+
+        [Test]
+        public void MockDriveInfoFactory_GetDrives_ShouldReturnOnlyLocalDrives()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\Test"));
+            fileSystem.AddDirectory(XFS.Path(@"Z:\Test"));
+            fileSystem.AddDirectory(XFS.Path(@"d:\Test"));
+            fileSystem.AddDirectory(XFS.Path(@"\\anunc\share\Zzz"));
+            var factory = new MockDriveInfoFactory(fileSystem);
+
+            // Act
+            var actualResults = factory.GetDrives();
+
+            var actualNames = actualResults.Select(d => d.Name);
+
+            // Assert
+            Assert.That(actualNames, Is.EquivalentTo(new[] { @"C:\", @"Z:\", @"D:\" }));
+        }
+
+        [Test]
+        public void MockDriveInfoFactory_FromDriveName_WithDriveShouldReturnDrive()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var factory = new MockDriveInfoFactory(fileSystem);
+
+            // Act
+            var actualResult = factory.FromDriveName(@"Z:\");
+
+            // Assert
+            Assert.That(actualResult.Name, Is.EquivalentTo(@"Z:\"));
+        }
+
+        [Test]
+        public void MockDriveInfoFactory_FromDriveName_WithPathShouldReturnDrive()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var factory = new MockDriveInfoFactory(fileSystem);
+
+            // Act
+            var actualResult = factory.FromDriveName(@"Z:\foo\bar\");
+
+            // Assert
+            Assert.That(actualResult.Name, Is.EquivalentTo(@"Z:\"));
+        }
+    }
+}

--- a/tests/MockDriveInfoTests.cs
+++ b/tests/MockDriveInfoTests.cs
@@ -1,0 +1,71 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    [WindowsOnly(WindowsSpecifics.Drives)]
+    public class MockDriveInfoTests
+    {
+        [TestCase(@"c:")]
+        [TestCase(@"c:\")]
+        public void MockDriveInfo_Constructor_ShouldInitializeLocalWindowsDrives(string driveName)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\Test"));
+            var path = XFS.Path(driveName);
+
+            // Act
+            var driveInfo = new MockDriveInfo(fileSystem, path);
+
+            // Assert
+            Assert.AreEqual(@"C:\", driveInfo.Name);
+        }
+
+        [Test]
+        public void MockDriveInfo_Constructor_ShouldInitializeLocalWindowsDrives_SpecialForWindows()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\Test"));
+
+            // Act
+            var driveInfo = new MockDriveInfo(fileSystem, "c");
+
+            // Assert
+            Assert.AreEqual(@"C:\", driveInfo.Name);
+        }
+
+        [TestCase(@"\\unc\share")]
+        [TestCase(@"\\unctoo")]
+        public void MockDriveInfo_Constructor_ShouldThrowExceptionIfUncPath(string driveName)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => new MockDriveInfo(fileSystem, XFS.Path(driveName));
+
+            // Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
+        public void MockDriveInfo_RootDirectory_ShouldReturnTheDirectoryBase()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\Test"));
+            var driveInfo = new MockDriveInfo(fileSystem, "c:");
+            var expectedDirectory = XFS.Path(@"C:\");
+
+            // Act
+            var actualDirectory = driveInfo.RootDirectory;
+
+            // Assert
+            Assert.AreEqual(expectedDirectory, actualDirectory.FullName);
+        }
+    }
+}

--- a/tests/MockFileAppendAllLinesTests.cs
+++ b/tests/MockFileAppendAllLinesTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    public class MockFileAppendAllLinesTests
+    {
+        [Test]
+        public void MockFile_AppendAllLines_ShouldPersistNewLinesToExistingFile()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("Demo text content") }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            file.AppendAllLines(path, new[] { "line 1", "line 2", "line 3" });
+
+            // Assert
+            Assert.AreEqual(
+                "Demo text contentline 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine,
+                file.ReadAllText(path));
+        }
+
+        [Test]
+        public void MockFile_AppendAllLines_ShouldPersistNewLinesToNewFile()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\"), new MockDirectoryData() }
+            });
+            var file = new MockFile(fileSystem);
+
+            // Act
+            file.AppendAllLines(path, new[] { "line 1", "line 2", "line 3" });
+
+            // Assert
+            Assert.AreEqual(
+                "line 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine,
+                file.ReadAllText(path));
+        }
+
+        [Test]
+        public void MockFile_AppendAllLines_ShouldThrowArgumentExceptionIfPathIsZeroLength()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.AppendAllLines(string.Empty, new[] { "does not matter" });
+
+            // Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockFile_AppendAllLines_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.AppendAllLines(path, new[] { "does not matter" });
+
+            // Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [TestCase("\"")]
+        [TestCase("<")]
+        [TestCase(">")]
+        [TestCase("|")]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+        public void MockFile_AppendAllLines_ShouldThrowArgumentExceptionIfPathContainsInvalidChar(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.AppendAllLines(path, new[] { "does not matter" });
+
+            // Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
+        public void MockFile_AppendAllLines_ShouldThrowArgumentNullExceptionIfContentIsNull()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.AppendAllLines("foo", null);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentNullException>(action);
+            Assert.That(exception.ParamName, Is.EqualTo("contents"));
+        }
+
+        [Test]
+        public void MockFile_AppendAllLines_ShouldThrowArgumentNullExceptionIfEncodingIsNull()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.AppendAllLines("foo.txt", new [] { "bar" }, null);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentNullException>(action);
+            Assert.That(exception.ParamName, Is.EqualTo("encoding"));
+        }
+    }
+}

--- a/tests/MockFileAppendAllTextTests.cs
+++ b/tests/MockFileAppendAllTextTests.cs
@@ -1,0 +1,147 @@
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using Collections.Generic;
+
+    using Globalization;
+
+    using NUnit.Framework;
+
+    using Text;
+
+    using XFS = MockUnixSupport;
+
+    public class MockFileAppendAllTextTests
+    {
+        [Test]
+        public void MockFile_AppendAllText_ShouldPersistNewText()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {path, new MockFileData("Demo text content")}
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            file.AppendAllText(path, "+ some text");
+
+            // Assert
+            Assert.AreEqual(
+                "Demo text content+ some text",
+                file.ReadAllText(path));
+        }
+
+        [Test]
+        public void MockFile_AppendAllText_ShouldPersistNewTextWithDifferentEncoding()
+        {
+            // Arrange
+            const string Path = @"c:\something\demo.txt";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {Path, new MockFileData("AA", Encoding.UTF32)}
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            file.AppendAllText(Path, "BB", Encoding.UTF8);
+
+            // Assert
+            CollectionAssert.AreEqual(
+                new byte[] {255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0, 66, 66},
+                fileSystem.GetFile(Path).Contents);
+        }
+
+        [Test]
+        public void MockFile_AppendAllText_ShouldCreateIfNotExist()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {path, new MockFileData("Demo text content")}
+            });
+
+            // Act
+            fileSystem.File.AppendAllText(path, " some text");
+
+            // Assert
+            Assert.AreEqual(
+                "Demo text content some text",
+                fileSystem.File.ReadAllText(path));
+        }
+
+        [Test]
+        public void MockFile_AppendAllText_ShouldCreateIfNotExistWithBom()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var path = XFS.Path(@"c:\something\demo3.txt");
+            fileSystem.AddDirectory(XFS.Path(@"c:\something\"));
+
+            // Act
+            fileSystem.File.AppendAllText(path, "AA", Encoding.UTF32);
+
+            // Assert
+            CollectionAssert.AreEqual(
+                new byte[] {255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0},
+                fileSystem.GetFile(path).Contents);
+        }
+
+        [Test]
+        public void MockFile_AppendAllText_ShouldFailIfNotExistButDirectoryAlsoNotExist()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {path, new MockFileData("Demo text content")}
+            });
+
+            // Act
+            path = XFS.Path(@"c:\something2\demo.txt");
+
+            // Assert
+            Exception ex;
+            ex = Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.AppendAllText(path, "some text"));
+            Assert.That(ex.Message,
+                Is.EqualTo(String.Format(CultureInfo.InvariantCulture, "Could not find a part of the path '{0}'.", path)));
+
+            ex =
+                Assert.Throws<DirectoryNotFoundException>(
+                    () => fileSystem.File.AppendAllText(path, "some text", Encoding.Unicode));
+            Assert.That(ex.Message,
+                Is.EqualTo(String.Format(CultureInfo.InvariantCulture, "Could not find a part of the path '{0}'.", path)));
+        }
+
+        [Test]
+        public void MockFile_AppendAllText_ShouldPersistNewTextWithCustomEncoding()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {path, new MockFileData("Demo text content")}
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            file.AppendAllText(path, "+ some text", Encoding.BigEndianUnicode);
+
+            // Assert
+            var expected = new byte[]
+            {
+                68, 101, 109, 111, 32, 116, 101, 120, 116, 32, 99, 111, 110, 116,
+                101, 110, 116, 0, 43, 0, 32, 0, 115, 0, 111, 0, 109, 0, 101,
+                0, 32, 0, 116, 0, 101, 0, 120, 0, 116
+            };
+
+            CollectionAssert.AreEqual(
+                expected,
+                file.ReadAllBytes(path));
+        }
+    }
+}

--- a/tests/MockFileArgumentPathTests.cs
+++ b/tests/MockFileArgumentPathTests.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    public class MockFileArgumentPathTests
+    {
+        private static IEnumerable<Action<FileBase>> GetFileSystemActionsForArgumentNullException()
+        {
+            yield return fs => fs.AppendAllLines(null, new[] { "does not matter" });
+            yield return fs => fs.AppendAllLines(null, new[] { "does not matter" }, Encoding.ASCII);
+            yield return fs => fs.AppendAllText(null, "does not matter");
+            yield return fs => fs.AppendAllText(null, "does not matter", Encoding.ASCII);
+            yield return fs => fs.AppendText(null);
+            yield return fs => fs.WriteAllBytes(null, new byte[] { 0 });
+            yield return fs => fs.WriteAllLines(null, new[] { "does not matter" });
+            yield return fs => fs.WriteAllLines(null, new[] { "does not matter" }, Encoding.ASCII);
+            yield return fs => fs.WriteAllLines(null, new[] { "does not matter" }.ToArray());
+            yield return fs => fs.WriteAllLines(null, new[] { "does not matter" }.ToArray(), Encoding.ASCII);
+            yield return fs => fs.Create(null);
+            yield return fs => fs.Delete(null);
+            yield return fs => fs.GetCreationTime(null);
+            yield return fs => fs.GetCreationTimeUtc(null);
+            yield return fs => fs.GetLastAccessTime(null);
+            yield return fs => fs.GetLastAccessTimeUtc(null);
+            yield return fs => fs.GetLastWriteTime(null);
+            yield return fs => fs.GetLastWriteTimeUtc(null);
+            yield return fs => fs.WriteAllText(null, "does not matter");
+            yield return fs => fs.WriteAllText(null, "does not matter", Encoding.ASCII);
+            yield return fs => fs.Open(null, FileMode.OpenOrCreate);
+            yield return fs => fs.Open(null, FileMode.OpenOrCreate, FileAccess.Read);
+            yield return fs => fs.Open(null, FileMode.OpenOrCreate, FileAccess.Read, FileShare.Inheritable);
+            yield return fs => fs.OpenRead(null);
+            yield return fs => fs.OpenText(null);
+            yield return fs => fs.OpenWrite(null);
+            yield return fs => fs.ReadAllBytes(null);
+            yield return fs => fs.ReadAllLines(null);
+            yield return fs => fs.ReadAllLines(null, Encoding.ASCII);
+            yield return fs => fs.ReadAllText(null);
+            yield return fs => fs.ReadAllText(null, Encoding.ASCII);
+            yield return fs => fs.ReadLines(null);
+            yield return fs => fs.ReadLines(null, Encoding.ASCII);
+            yield return fs => fs.SetAttributes(null, FileAttributes.Archive);
+            yield return fs => fs.GetAttributes(null);
+            yield return fs => fs.SetCreationTime(null, DateTime.Now);
+            yield return fs => fs.SetCreationTimeUtc(null, DateTime.Now);
+            yield return fs => fs.SetLastAccessTime(null, DateTime.Now);
+            yield return fs => fs.SetLastAccessTimeUtc(null, DateTime.Now);
+            yield return fs => fs.SetLastWriteTime(null, DateTime.Now);
+            yield return fs => fs.SetLastWriteTimeUtc(null, DateTime.Now);
+#if NET40
+            yield return fs => fs.Decrypt(null);
+            yield return fs => fs.Encrypt(null);
+#endif
+        }
+
+        [TestCaseSource("GetFileSystemActionsForArgumentNullException")]
+        public void Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(Action<FileBase> action)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate wrapped = () => action(fileSystem.File);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentNullException>(wrapped);
+            Assert.AreEqual("path", exception.ParamName);
+        }
+    }
+}

--- a/tests/MockFileCopyTests.cs
+++ b/tests/MockFileCopyTests.cs
@@ -1,0 +1,372 @@
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using Collections.Generic;
+    using Globalization;
+    using Linq;
+    using NUnit.Framework;
+    using XFS = MockUnixSupport;
+
+    public class MockFileCopyTests
+    {
+
+        [Test]
+        public void MockFile_Copy_ShouldOverwriteFileWhenOverwriteFlagIsTrue()
+        {
+            string sourceFileName = XFS.Path(@"c:\source\demo.txt");
+            var sourceContents = new MockFileData("Source content");
+            string destFileName = XFS.Path(@"c:\destination\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {sourceFileName, sourceContents},
+                {destFileName, new MockFileData("Destination content")}
+            });
+
+            fileSystem.File.Copy(sourceFileName, destFileName, true);
+
+            var copyResult = fileSystem.GetFile(destFileName);
+            Assert.AreEqual(copyResult.Contents, sourceContents.Contents);
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldCloneContents()
+        {
+            var sourceFileName = XFS.Path(@"c:\source\demo.txt");
+            var destFileName = XFS.Path(@"c:\source\demo_copy.txt");
+
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.AddFile(sourceFileName, "Original");
+            mockFileSystem.File.Copy(sourceFileName, destFileName);
+            
+            using (var stream = mockFileSystem.File.Open(sourceFileName, FileMode.Open, FileAccess.ReadWrite))
+            {
+                var binaryWriter = new System.IO.BinaryWriter(stream);
+
+                binaryWriter.Seek(0, SeekOrigin.Begin);
+                binaryWriter.Write("Modified");
+            }
+
+            Assert.AreEqual("Original", mockFileSystem.File.ReadAllText(destFileName));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldCloneBinaryContents()
+        {
+            var sourceFileName = XFS.Path(@"c:\source\demo.bin");
+            var destFileName = XFS.Path(@"c:\source\demo_copy.bin");
+
+            byte[] original = new byte[] { 0xC0 };
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.AddFile(sourceFileName, new MockFileData(original));
+            mockFileSystem.File.Copy(sourceFileName, destFileName);
+
+            using (var stream = mockFileSystem.File.Open(sourceFileName, FileMode.Open, FileAccess.ReadWrite))
+            {
+                var binaryWriter = new System.IO.BinaryWriter(stream);
+
+                binaryWriter.Seek(0, SeekOrigin.Begin);
+                binaryWriter.Write("Modified");
+            }
+
+            CollectionAssert.AreEqual(original, mockFileSystem.File.ReadAllBytes(destFileName));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldCreateFileAtNewDestination()
+        {
+            string sourceFileName = XFS.Path(@"c:\source\demo.txt");
+            var sourceContents = new MockFileData("Source content");
+            string destFileName = XFS.Path(@"c:\source\demo_copy.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {sourceFileName, sourceContents}
+            });
+
+            fileSystem.File.Copy(sourceFileName, destFileName, false);
+
+            var copyResult = fileSystem.GetFile(destFileName);
+            Assert.AreEqual(copyResult.Contents, sourceContents.Contents);
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowExceptionWhenFileExistsAtDestination()
+        {
+            string sourceFileName = XFS.Path(@"c:\source\demo.txt");
+            var sourceContents = new MockFileData("Source content");
+            string destFileName = XFS.Path(@"c:\destination\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {sourceFileName, sourceContents},
+                {destFileName, new MockFileData("Destination content")}
+            });
+
+            Assert.Throws<IOException>(() => fileSystem.File.Copy(sourceFileName, destFileName), XFS.Path(@"The file c:\destination\demo.txt already exists."));
+        }
+
+        [TestCase(@"c:\source\demo.txt", @"c:\source\doesnotexist\demo.txt")]
+        [TestCase(@"c:\source\demo.txt", @"c:\doesnotexist\demo.txt")]
+        public void MockFile_Copy_ShouldThrowExceptionWhenFolderInDestinationDoesNotExist(string sourceFilePath, string destFilePath)
+        {
+            string sourceFileName = XFS.Path(sourceFilePath);
+            string destFileName = XFS.Path(destFilePath);
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {sourceFileName, MockFileData.NullObject}
+            });
+
+            Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.Copy(sourceFileName, destFileName), string.Format(CultureInfo.InvariantCulture, @"Could not find a part of the path '{0}'.", destFilePath));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentNullExceptionWhenSourceIsNull_Message()
+        {
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Copy(null, destFilePath));
+
+            Assert.That(exception.Message, Does.StartWith("File name cannot be null."));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentNullExceptionWhenSourceIsNull_ParamName()
+        {
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Copy(null, destFilePath));
+
+            Assert.That(exception.ParamName, Is.EqualTo("sourceFileName"));
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceFileNameContainsInvalidChars_Message()
+        {
+            var destFilePath = @"c:\something\demo.txt";
+            var fileSystem = new MockFileSystem();
+            var excludeChars = Shared.SpecialInvalidPathChars(fileSystem);
+
+            foreach (var invalidChar in fileSystem.Path.GetInvalidFileNameChars().Except(excludeChars))
+            {
+                var sourceFilePath = @"c:\something\demo.txt" + invalidChar;
+
+                var exception =
+                    Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+
+                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
+                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+            }
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenSourcePathContainsInvalidChars_Message()
+        {
+            var destFilePath = @"c:\something\demo.txt";
+            var fileSystem = new MockFileSystem();
+
+            foreach (var invalidChar in fileSystem.Path.GetInvalidPathChars())
+            {
+                var sourceFilePath = @"c:\some" + invalidChar + @"thing\demo.txt";
+
+                var exception =
+                    Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+
+                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
+                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+            }
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenTargetPathContainsInvalidChars_Message()
+        {
+            var sourceFilePath = @"c:\something\demo.txt";
+            var fileSystem = new MockFileSystem();
+
+            foreach (var invalidChar in fileSystem.Path.GetInvalidPathChars())
+            {
+                var destFilePath = @"c:\some" + invalidChar + @"thing\demo.txt";
+
+                var exception =
+                    Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+
+                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
+                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+            }
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenTargetFileNameContainsInvalidChars_Message()
+        {
+            var sourceFilePath = @"c:\something\demo.txt";
+            var fileSystem = new MockFileSystem();
+            var excludeChars = Shared.SpecialInvalidPathChars(fileSystem);
+
+            foreach (var invalidChar in fileSystem.Path.GetInvalidFileNameChars().Except(excludeChars))
+            {
+                var destFilePath = @"c:\something\demo.txt" + invalidChar;
+
+                var exception =
+                    Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+
+                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
+                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+            }
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void MockFile_Copy_ShouldThrowNotSupportedExceptionWhenSourcePathContainsInvalidUseOfDriveSeparator()
+        {
+            var badSourcePath = @"C::\something\demo.txt";
+            var destinationPath = @"C:\elsewhere\demo.txt";
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.Copy(badSourcePath, destinationPath);
+
+            Assert.Throws<NotSupportedException>(action);
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void MockFile_Copy_ShouldThrowNotSupportedExceptionWhenSourcePathContainsInvalidDriveLetter()
+        {
+            var badSourcePath = @"0:\something\demo.txt";
+            var destinationPath = @"C:\elsewhere\demo.txt";
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.Copy(badSourcePath, destinationPath);
+
+            Assert.Throws<NotSupportedException>(action);
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void MockFile_Copy_ShouldThrowNotSupportedExceptionWhenDestinationPathContainsInvalidUseOfDriveSeparator()
+        {
+            var sourcePath = @"C:\something\demo.txt";
+            var badDestinationPath = @"C:\elsewhere:\demo.txt";
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.Copy(sourcePath, badDestinationPath);
+
+            Assert.Throws<NotSupportedException>(action);
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void MockFile_Copy_ShouldThrowNotSupportedExceptionWhenDestinationPathContainsInvalidDriveLetter()
+        {
+            var sourcePath = @"C:\something\demo.txt";
+            var badDestinationPath = @"^:\elsewhere\demo.txt";
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.Copy(sourcePath, badDestinationPath);
+
+            Assert.Throws<NotSupportedException>(action);
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceIsEmpty_Message()
+        {
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(string.Empty, destFilePath));
+
+            Assert.That(exception.Message, Does.StartWith("Empty file name is not legal."));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceIsEmpty_ParamName()
+        {
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(string.Empty, destFilePath));
+
+            Assert.That(exception.ParamName, Is.EqualTo("sourceFileName"));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceIsStringOfBlanks()
+        {
+            string sourceFilePath = "   ";
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+
+            Assert.That(exception.Message, Does.StartWith("The path is not of a legal form."));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentNullExceptionWhenTargetIsNull_Message()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Copy(sourceFilePath, null));
+
+            Assert.That(exception.Message, Does.StartWith("File name cannot be null."));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentNullExceptionWhenTargetIsNull_ParamName()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Copy(sourceFilePath, null));
+
+            Assert.That(exception.ParamName, Is.EqualTo("destFileName"));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenTargetIsStringOfBlanks()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            string destFilePath = "   ";
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+
+            Assert.That(exception.Message, Does.StartWith("The path is not of a legal form."));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenTargetIsEmpty_Message()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, string.Empty));
+
+            Assert.That(exception.Message, Does.StartWith("Empty file name is not legal."));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowFileNotFoundExceptionWhenSourceDoesNotExist()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.Copy(sourceFilePath, XFS.Path(@"c:\something\demo2.txt"));
+
+            Assert.Throws<FileNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowFileNotFoundExceptionWhenSourceDoesNotExist_EvenWhenCopyingToItself()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.Copy(sourceFilePath, XFS.Path(@"c:\something\demo.txt"));
+
+            Assert.Throws<FileNotFoundException>(action);
+        }
+    }
+}

--- a/tests/MockFileCreateTests.cs
+++ b/tests/MockFileCreateTests.cs
@@ -1,0 +1,283 @@
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using Collections.Generic;
+
+    using Globalization;
+
+    using NUnit.Framework;
+
+    using Text;
+
+    using XFS = MockUnixSupport;
+
+    public class MockFileCreateTests
+    {
+        [Test]
+        public void Mockfile_Create_ShouldCreateNewStream()
+        {
+            string fullPath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+
+            var sut = new MockFile(fileSystem);
+
+            Assert.That(fileSystem.FileExists(fullPath), Is.False);
+
+            sut.Create(fullPath).Dispose();
+
+            Assert.That(fileSystem.FileExists(fullPath), Is.True);
+        }
+
+        [Test]
+        public void Mockfile_Create_CanWriteToNewStream()
+        {
+            string fullPath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+            var data = new UTF8Encoding(false).GetBytes("Test string");
+
+            var sut = new MockFile(fileSystem);
+            using (var stream = sut.Create(fullPath))
+            {
+                stream.Write(data, 0, data.Length);
+            }
+
+            var mockFileData = fileSystem.GetFile(fullPath);
+            var fileData = mockFileData.Contents;
+
+            Assert.That(fileData, Is.EqualTo(data));
+        }
+
+        [Test]
+        public void Mockfile_Create_OverwritesExistingFile()
+        {
+            string path = XFS.Path(@"c:\some\file.txt");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\some"));
+
+            var mockFile = new MockFile(fileSystem);
+
+            // Create a file
+            using (var stream = mockFile.Create(path))
+            {
+                var contents = new UTF8Encoding(false).GetBytes("Test 1");
+                stream.Write(contents, 0, contents.Length);
+            }
+
+            // Create new file that should overwrite existing file
+            var expectedContents = new UTF8Encoding(false).GetBytes("Test 2");
+            using (var stream = mockFile.Create(path))
+            {
+                stream.Write(expectedContents, 0, expectedContents.Length);
+            }
+
+            var actualContents = fileSystem.GetFile(path).Contents;
+
+            Assert.That(actualContents, Is.EqualTo(expectedContents));
+        }
+
+        [Test]
+        public void Mockfile_Create_ShouldThrowUnauthorizedAccessExceptionIfPathIsReadOnly()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\read-only.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData> { { path, new MockFileData("Content") } });
+            var mockFile = new MockFile(fileSystem);
+
+            // Act
+            mockFile.SetAttributes(path, FileAttributes.ReadOnly);
+
+            // Assert
+            var exception =  Assert.Throws<UnauthorizedAccessException>(() => mockFile.Create(path).Dispose());
+            Assert.That(exception.Message, Is.EqualTo(string.Format(CultureInfo.InvariantCulture, "Access to the path '{0}' is denied.", path)));
+        }
+
+        [Test]
+        public void Mockfile_Create_ShouldThrowArgumentExceptionIfPathIsZeroLength()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.Create("");
+
+            // Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [TestCase("\"")]
+        [TestCase("<")]
+        [TestCase(">")]
+        [TestCase("|")]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+        public void MockFile_Create_ShouldThrowArgumentNullExceptionIfPathIsNull1(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.Create(path);
+
+            // Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockFile_Create_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.Create(path);
+
+            // Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
+        public void MockFile_Create_ShouldThrowArgumentNullExceptionIfPathIsNull()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.Create(null);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentNullException>(action);
+            Assert.That(exception.Message, Does.StartWith("Path cannot be null."));
+        }
+
+        [Test]
+        public void MockFile_Create_ShouldThrowDirectoryNotFoundExceptionIfCreatingAndParentPathDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.Create("C:\\Path\\NotFound.ext");
+
+            // Assert
+            Assert.IsFalse(fileSystem.Directory.Exists("C:\\path"));
+            var exception = Assert.Throws<DirectoryNotFoundException>(action);
+            Assert.That(exception.Message, Does.StartWith("Could not find a part of the path"));
+        }
+
+        [Test]
+        public void MockFile_Create_TruncateShouldWriteNewContents()
+        {
+            // Arrange
+            const string testFileName = @"c:\someFile.txt";
+            var fileSystem = new MockFileSystem();
+            
+            using (var stream = fileSystem.FileStream.Create(testFileName, FileMode.Create, FileAccess.Write))
+            {
+                using (var writer = new StreamWriter(stream))
+                {
+                    writer.Write("original_text");
+                }
+            }
+
+            // Act
+            using (var stream = fileSystem.FileStream.Create(testFileName, FileMode.Truncate, FileAccess.Write))
+            {
+                using (var writer = new StreamWriter(stream))
+                {
+                    writer.Write("new_text");
+                }
+            }
+
+            // Assert
+            Assert.That(fileSystem.File.ReadAllText(testFileName), Is.EqualTo("new_text"));
+        }
+
+        [Test]
+        public void MockFile_Create_TruncateShouldClearFileContentsOnOpen()
+        {
+            // Arrange
+            const string testFileName = @"c:\someFile.txt";
+            var fileSystem = new MockFileSystem();
+
+            using (var stream = fileSystem.FileStream.Create(testFileName, FileMode.Create, FileAccess.Write))
+            {
+                using (var writer = new StreamWriter(stream))
+                {
+                    writer.Write("original_text");
+                }
+            }
+
+            // Act
+            using (var stream = fileSystem.FileStream.Create(testFileName, FileMode.Truncate, FileAccess.Write))
+            {
+                // Opening the stream is enough to reset the contents
+            }
+
+            // Assert
+            Assert.That(fileSystem.File.ReadAllText(testFileName), Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void MockFile_Create_DeleteOnCloseOption_FileExistsWhileStreamIsOpen()
+        {
+            var root = XFS.Path(@"C:\");
+            var filePath = XFS.Path(@"C:\test.txt");
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(root);
+
+            using (fileSystem.File.Create(filePath, 4096, FileOptions.DeleteOnClose))
+            {
+                Assert.IsTrue(fileSystem.File.Exists(filePath));
+            }
+        }
+
+        [Test]
+        public void MockFile_Create_DeleteOnCloseOption_FileDeletedWhenStreamIsClosed()
+        {
+            var root = XFS.Path(@"C:\");
+            var filePath = XFS.Path(@"C:\test.txt");
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(root);
+
+            using (fileSystem.File.Create(filePath, 4096, FileOptions.DeleteOnClose))
+            {
+            }
+
+            Assert.IsFalse(fileSystem.File.Exists(filePath));
+        }
+
+#if NET40
+        [Test]
+        public void MockFile_Create_EncryptedOption_FileNotYetEncryptedsWhenStreamIsOpen()
+        {
+            var root = XFS.Path(@"C:\");
+            var filePath = XFS.Path(@"C:\test.txt");
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(root);
+
+            using (var stream = fileSystem.File.Create(filePath, 4096, FileOptions.Encrypted))
+            {
+                var fileInfo = fileSystem.FileInfo.FromFileName(filePath);
+                Assert.IsFalse(fileInfo.Attributes.HasFlag(FileAttributes.Encrypted));
+            }
+        }
+
+        [Test]
+        public void MockFile_Create_EncryptedOption_EncryptsFileWhenStreamIsClose()
+        {
+            var root = XFS.Path(@"C:\");
+            var filePath = XFS.Path(@"C:\test.txt");
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(root);
+
+            using (var stream = fileSystem.File.Create(filePath, 4096, FileOptions.Encrypted))
+            {
+            }
+
+            var fileInfo = fileSystem.FileInfo.FromFileName(filePath);
+            Assert.IsTrue(fileInfo.Attributes.HasFlag(FileAttributes.Encrypted));
+        }
+#endif
+    }
+}

--- a/tests/MockFileDeleteTests.cs
+++ b/tests/MockFileDeleteTests.cs
@@ -1,0 +1,63 @@
+﻿namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+  using System.Collections.Generic;
+  using NUnit.Framework;
+
+    using XFS = MockUnixSupport;
+
+    public class MockFileDeleteTests
+    {
+        [Test]
+        public void MockFile_Delete_ShouldDeleteFile()
+        {
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path("C:\\some_folder\\test");
+            var directory = fileSystem.Path.GetDirectoryName(path);
+            fileSystem.AddFile(path, new MockFileData("Bla"));
+
+            var fileCount1 = fileSystem.Directory.GetFiles(directory, "*").Length;
+            fileSystem.File.Delete(path);
+            var fileCount2 = fileSystem.Directory.GetFiles(directory, "*").Length;
+
+            Assert.AreEqual(1, fileCount1, "File should have existed");
+            Assert.AreEqual(0, fileCount2, "File should have been deleted");
+        }
+
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockFile_Delete_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.Delete(path);
+
+            // Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
+        public void MockFile_Delete_ShouldThrowDirectoryNotFoundExceptionIfParentFolderAbsent()
+        {
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path("C:\\test\\somefile.txt");
+
+            Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.Delete(path));
+        }
+
+        [Test]
+        public void MockFile_Delete_ShouldSilentlyReturnIfNonExistingFileInExistingFolder()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { XFS.Path("C:\\temp\\exist.txt"), new MockFileData("foobar") },
+            });
+
+            string filePath = XFS.Path("C:\\temp\\somefile.txt");
+
+            // Delete() returns void, so there is nothing to check here beside absense of an exception
+            Assert.DoesNotThrow(() => fileSystem.File.Delete(filePath));
+        }
+    }
+}

--- a/tests/MockFileExistsTests.cs
+++ b/tests/MockFileExistsTests.cs
@@ -1,0 +1,94 @@
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using Collections.Generic;
+
+    using NUnit.Framework;
+
+    using XFS = MockUnixSupport;
+
+    public class MockFileExistsTests {
+        [Test]
+        public void MockFile_Exists_ShouldReturnTrueForSamePath()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var result = file.Exists(XFS.Path(@"c:\something\other.gif"));
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void MockFile_Exists_ShouldReturnTrueForPathVaryingByCase()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var result = file.Exists(XFS.Path(@"c:\SomeThing\Other.gif"));
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void MockFile_Exists_ShouldReturnFalseForEntirelyDifferentPath()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var result = file.Exists(XFS.Path(@"c:\SomeThing\DoesNotExist.gif"));
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void MockFile_Exists_ShouldReturnFalseForNullPath()
+        {
+            var file = new MockFile(new MockFileSystem());
+
+            Assert.That(file.Exists(null), Is.False);
+        }
+
+        [Test]
+        public void MockFile_Exists_ShouldReturnFalseForDirectories()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var result = file.Exists(XFS.Path(@"c:\SomeThing\"));
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+    }
+}

--- a/tests/MockFileGetAccessControlTests.cs
+++ b/tests/MockFileGetAccessControlTests.cs
@@ -1,0 +1,70 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Security.AccessControl;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    [WindowsOnly(WindowsSpecifics.AccessControlLists)]
+    public class MockFileGetAccessControlTests
+    {
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockFile_GetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.GetAccessControl(path);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockFile_GetAccessControl_ShouldThrowFileNotFoundExceptionIfFileDoesNotExistInMockData()
+        {   
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var expectedFileName = XFS.Path(@"c:\a.txt");
+
+            // Act
+            TestDelegate action = () => fileSystem.File.GetAccessControl(expectedFileName);
+
+            // Assert
+            Assert.Throws<FileNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockFile_GetAccessControl_ShouldReturnAccessControlOfFileData()
+        {
+            // Arrange
+            var expectedFileSecurity = new FileSecurity();
+            expectedFileSecurity.SetAccessRuleProtection(false, false);
+
+            var filePath = XFS.Path(@"c:\a.txt");
+            var fileData = new MockFileData("Test content")
+            {
+                AccessControl = expectedFileSecurity,
+            };
+
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { filePath, fileData }
+            });
+
+            // Act
+            var fileSecurity = fileSystem.File.GetAccessControl(filePath);
+
+            // Assert
+            Assert.That(fileSecurity, Is.EqualTo(expectedFileSecurity));
+        }
+    }
+}

--- a/tests/MockFileGetCreationTimeTests.cs
+++ b/tests/MockFileGetCreationTimeTests.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockFileGetCreationTimeTests
+    {
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockFile_GetCreationTime_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.GetCreationTime(path);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockFile_GetCreationTime_ShouldReturnDefaultTimeIfFileDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            var actualCreationTime = fileSystem.File.GetCreationTime(@"c:\does\not\exist.txt");
+
+            // Assert
+            Assert.AreEqual(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime(), actualCreationTime);
+        }
+    }
+}

--- a/tests/MockFileGetCreationTimeUtcTests.cs
+++ b/tests/MockFileGetCreationTimeUtcTests.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockFileGetCreationTimeUtcTests
+    {
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockFile_GetCreationTimeUtc_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.GetCreationTimeUtc(path);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockFile_GetCreationTimeUtc_ShouldReturnDefaultTimeIfFileDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            var actualCreationTime = fileSystem.File.GetCreationTimeUtc(@"c:\does\not\exist.txt");
+
+            // Assert
+            Assert.AreEqual(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc), actualCreationTime);
+        }
+    }
+}

--- a/tests/MockFileGetLastAccessTimeTests.cs
+++ b/tests/MockFileGetLastAccessTimeTests.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockFileGetLastAccessTimeTests
+    {
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockFile_GetLastAccessTime_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.GetLastAccessTime(path);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockFile_GetLastAccessTime_ShouldReturnDefaultTimeIfFileDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            var actualLastAccessTime = fileSystem.File.GetLastAccessTime(@"c:\does\not\exist.txt");
+
+            // Assert
+            Assert.AreEqual(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime(), actualLastAccessTime);
+        }
+    }
+}

--- a/tests/MockFileGetLastAccessTimeUtcTests.cs
+++ b/tests/MockFileGetLastAccessTimeUtcTests.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockFileGetLastAccessTimeUtcTests
+    {
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockFile_GetLastAccessTimeUtc_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.GetLastAccessTimeUtc(path);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockFile_GetLastAccessTimeUtc_ShouldReturnDefaultTimeIfFileDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc(@"c:\does\not\exist.txt");
+
+            // Assert
+            Assert.AreEqual(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc), actualLastAccessTime);
+        }
+    }
+}

--- a/tests/MockFileGetLastWriteTimeTests.cs
+++ b/tests/MockFileGetLastWriteTimeTests.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockFileGetLastWriteTimeTests
+    {
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockFile_GetLastWriteTime_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.GetLastWriteTime(path);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockFile_GetLastWriteTime_ShouldReturnDefaultTimeIfFileDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            var actualLastWriteTime = fileSystem.File.GetLastWriteTime(@"c:\does\not\exist.txt");
+
+            // Assert
+            Assert.AreEqual(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime(), actualLastWriteTime);
+        }
+    }
+}

--- a/tests/MockFileGetLastWriteTimeUtcTests.cs
+++ b/tests/MockFileGetLastWriteTimeUtcTests.cs
@@ -1,0 +1,35 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    public class MockFileGetLastWriteTimeUtcTests
+    {
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockFile_GetLastWriteTimeUtc_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.GetLastWriteTimeUtc(path);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockFile_GetLastWriteTimeUtc_ShouldReturnDefaultTimeIfFileDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc(@"c:\does\not\exist.txt");
+
+            // Assert
+            Assert.AreEqual(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc), actualLastWriteTime);
+        }
+    }
+}

--- a/tests/MockFileInfoAccessControlTests.cs
+++ b/tests/MockFileInfoAccessControlTests.cs
@@ -1,0 +1,63 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using System.Security.AccessControl;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    [WindowsOnly(WindowsSpecifics.AccessControlLists)]
+    public class MockFileInfoAccessControlTests
+    {
+        [Test]
+        public void MockFileInfo_GetAccessControl_ShouldReturnAccessControlOfFileData()
+        {
+            // Arrange
+            var expectedFileSecurity = new FileSecurity();
+            expectedFileSecurity.SetAccessRuleProtection(false, false);
+
+            var filePath = XFS.Path(@"c:\a.txt");
+            var fileData = new MockFileData("Test content")
+            {
+                AccessControl = expectedFileSecurity,
+            };
+
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { filePath, fileData }
+            });
+
+            var fileInfo = fileSystem.FileInfo.FromFileName(filePath);
+
+            // Act
+            var fileSecurity = fileInfo.GetAccessControl();
+
+            // Assert
+            Assert.That(fileSecurity, Is.EqualTo(expectedFileSecurity));
+        }
+
+        [Test]
+        public void MockFile_SetAccessControl_ShouldSetAccessControlOfFileData()
+        {
+            // Arrange
+            var filePath = XFS.Path(@"c:\a.txt");
+            var fileData = new MockFileData("Test content");
+
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { filePath, fileData }
+            });
+
+            var fileInfo = fileSystem.FileInfo.FromFileName(filePath);
+
+            // Act
+            var expectedAccessControl = new FileSecurity();
+            expectedAccessControl.SetAccessRuleProtection(false, false);
+            fileInfo.SetAccessControl(expectedAccessControl);
+
+            // Assert
+            var accessControl = fileInfo.GetAccessControl();
+            Assert.That(accessControl, Is.EqualTo(expectedAccessControl));
+        }
+    }
+}

--- a/tests/MockFileInfoFactoryTests.cs
+++ b/tests/MockFileInfoFactoryTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework; 
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockFileInfoFactoryTests
+    {
+        [Test]
+        public void MockFileInfoFactory_FromFileName_ShouldReturnFileInfoForExistingFile()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\a.txt", new MockFileData("Demo text content") },
+                { @"c:\a\b\c.txt", new MockFileData("Demo text content") },
+            });
+            var fileInfoFactory = new MockFileInfoFactory(fileSystem);
+
+            // Act
+            var result = fileInfoFactory.FromFileName(@"c:\a.txt");
+
+            // Assert
+            Assert.IsNotNull(result);
+        }
+
+        [Test]
+        public void MockFileInfoFactory_FromFileName_ShouldReturnFileInfoForNonExistantFile()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\a.txt", new MockFileData("Demo text content") },
+                { @"c:\a\b\c.txt", new MockFileData("Demo text content") },
+            });
+            var fileInfoFactory = new MockFileInfoFactory(fileSystem);
+
+            // Act
+            var result = fileInfoFactory.FromFileName(@"c:\foo.txt");
+
+            // Assert
+            Assert.IsNotNull(result);
+        }
+    }
+}

--- a/tests/MockFileInfoTests.cs
+++ b/tests/MockFileInfoTests.cs
@@ -1,0 +1,593 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    public class MockFileInfoTests
+    {
+        [Test]
+        public void MockFileInfo_NullPath_ThrowArgumentNullException()
+        {
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => new MockFileInfo(fileSystem, null);
+
+            Assert.Throws<ArgumentNullException>(action);
+
+        }
+
+        [Test]
+        public void MockFileInfo_Exists_ShouldReturnTrueIfFileExistsInMemoryFileSystem()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\b\c.txt"), new MockFileData("Demo text content") },
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            var result = fileInfo.Exists;
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void MockFileInfo_Exists_ShouldReturnFalseIfFileDoesNotExistInMemoryFileSystem()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\a\b\c.txt"), new MockFileData("Demo text content") },
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\foo.txt"));
+
+            var result = fileInfo.Exists;
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void MockFileInfo_Length_ShouldReturnLengthOfFileInMemoryFileSystem()
+        {
+            const string fileContent = "Demo text content";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), new MockFileData(fileContent) },
+                { XFS.Path(@"c:\a\b\c.txt"), new MockFileData(fileContent) },
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            var result = fileInfo.Length;
+
+            Assert.AreEqual(fileContent.Length, result);
+        }
+
+        [Test]
+        public void MockFileInfo_Length_ShouldThrowFileNotFoundExceptionIfFileDoesNotExistInMemoryFileSystem()
+        {
+            const string fileContent = "Demo text content";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), new MockFileData(fileContent) },
+                { XFS.Path(@"c:\a\b\c.txt"), new MockFileData(fileContent) },
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\foo.txt"));
+
+            var ex = Assert.Throws<FileNotFoundException>(() => fileInfo.Length.ToString(CultureInfo.InvariantCulture));
+
+            Assert.AreEqual(XFS.Path(@"c:\foo.txt"), ex.FileName);
+        }
+
+        [Test]
+        public void MockFileInfo_CreationTimeUtc_ShouldReturnCreationTimeUtcOfFileInMemoryFileSystem()
+        {
+            var creationTime = DateTime.Now.AddHours(-4);
+            var fileData = new MockFileData("Demo text content") { CreationTime = creationTime };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            var result = fileInfo.CreationTimeUtc;
+
+            Assert.AreEqual(creationTime.ToUniversalTime(), result);
+        }
+
+        [Test]
+        public void MockFileInfo_CreationTimeUtc_ShouldSetCreationTimeUtcOfFileInMemoryFileSystem()
+        {
+            var creationTime = DateTime.Now.AddHours(-4);
+            var fileData = new MockFileData("Demo text content") { CreationTime = creationTime };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            var newUtcTime = DateTime.UtcNow;
+            fileInfo.CreationTimeUtc = newUtcTime;
+
+            Assert.AreEqual(newUtcTime, fileInfo.CreationTimeUtc);
+        }
+
+
+        [Test]
+        public void MockFileInfo_CreationTime_ShouldReturnCreationTimeOfFileInMemoryFileSystem()
+        {
+            var creationTime = DateTime.Now.AddHours(-4);
+            var fileData = new MockFileData("Demo text content") { CreationTime = creationTime };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            var result = fileInfo.CreationTime;
+
+            Assert.AreEqual(creationTime, result);
+        }
+
+        [Test]
+        public void MockFileInfo_CreationTime_ShouldSetCreationTimeOfFileInMemoryFileSystem()
+        {
+            var creationTime = DateTime.Now.AddHours(-4);
+            var fileData = new MockFileData("Demo text content") { CreationTime = creationTime };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+            var newTime = DateTime.Now;
+
+            fileInfo.CreationTime = newTime;
+
+            Assert.AreEqual(newTime, fileInfo.CreationTime);
+        }
+
+        [Test]
+        public void MockFileInfo_IsReadOnly_ShouldSetReadOnlyAttributeOfFileInMemoryFileSystem()
+        {
+            var fileData = new MockFileData("Demo text content");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            fileInfo.IsReadOnly = true;
+
+            Assert.AreEqual(FileAttributes.ReadOnly, fileData.Attributes & FileAttributes.ReadOnly);
+        }
+
+        [Test]
+        public void MockFileInfo_IsReadOnly_ShouldSetNotReadOnlyAttributeOfFileInMemoryFileSystem()
+        {
+            var fileData = new MockFileData("Demo text content") {Attributes = FileAttributes.ReadOnly};
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            fileInfo.IsReadOnly = false;
+
+            Assert.AreNotEqual(FileAttributes.ReadOnly, fileData.Attributes & FileAttributes.ReadOnly);
+        }
+
+        [Test]
+        public void MockFileInfo_AppendText_ShouldAddTextToFileInMemoryFileSystem()
+        {
+            var fileData = new MockFileData("Demo text content");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            using (var file = fileInfo.AppendText())
+                file.WriteLine("This should be at the end");
+
+            string newcontents;
+            using (var newfile = fileInfo.OpenText())
+            {
+                newcontents = newfile.ReadToEnd();
+            }
+
+            Assert.AreEqual($"Demo text contentThis should be at the end{Environment.NewLine}", newcontents);
+        }
+
+        [Test]
+        public void MockFileInfo_OpenWrite_ShouldAddDataToFileInMemoryFileSystem()
+        {
+            var fileData = new MockFileData("Demo text content");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+            var bytesToAdd = new byte[] {65, 66, 67, 68, 69};
+
+
+            using (var file = fileInfo.OpenWrite())
+            {
+                file.Write(bytesToAdd, 0, bytesToAdd.Length);
+            }
+
+            string newcontents;
+            using (var newfile = fileInfo.OpenText())
+            {
+                newcontents = newfile.ReadToEnd();
+            }
+
+            Assert.AreEqual("ABCDEtext content", newcontents);
+        }
+#if NET40
+        [Test]
+        public void MockFileInfo_Encrypt_ShouldSetEncryptedAttributeOfFileInMemoryFileSystem()
+        {
+            var fileData = new MockFileData("Demo text content");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            fileInfo.Encrypt();
+
+            Assert.AreEqual(FileAttributes.Encrypted, fileData.Attributes & FileAttributes.Encrypted);
+        }
+
+        [Test]
+        public void MockFileInfo_Decrypt_ShouldUnsetEncryptedAttributeOfFileInMemoryFileSystem()
+        {
+            var fileData = new MockFileData("Demo text content");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+            fileInfo.Encrypt();
+
+            fileInfo.Decrypt();
+
+            Assert.AreNotEqual(FileAttributes.Encrypted, fileData.Attributes & FileAttributes.Encrypted);
+        }
+#endif
+
+        [Test]
+        public void MockFileInfo_LastAccessTimeUtc_ShouldReturnLastAccessTimeUtcOfFileInMemoryFileSystem()
+        {
+            var lastAccessTime = DateTime.Now.AddHours(-4);
+            var fileData = new MockFileData("Demo text content") { LastAccessTime = lastAccessTime };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            var result = fileInfo.LastAccessTimeUtc;
+
+            Assert.AreEqual(lastAccessTime.ToUniversalTime(), result);
+        }
+
+        [Test]
+        public void MockFileInfo_LastAccessTimeUtc_ShouldSetCreationTimeUtcOfFileInMemoryFileSystem()
+        {
+            var lastAccessTime = DateTime.Now.AddHours(-4);
+            var fileData = new MockFileData("Demo text content") { LastAccessTime = lastAccessTime };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            var newUtcTime = DateTime.UtcNow;
+            fileInfo.LastAccessTimeUtc = newUtcTime;
+
+            Assert.AreEqual(newUtcTime, fileInfo.LastAccessTimeUtc);
+        }
+
+        [Test]
+        public void MockFileInfo_LastWriteTimeUtc_ShouldReturnLastWriteTimeUtcOfFileInMemoryFileSystem()
+        {
+            var lastWriteTime = DateTime.Now.AddHours(-4);
+            var fileData = new MockFileData("Demo text content") { LastWriteTime = lastWriteTime };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            var result = fileInfo.LastWriteTimeUtc;
+
+            Assert.AreEqual(lastWriteTime.ToUniversalTime(), result);
+        }
+
+        [Test]
+        public void MockFileInfo_LastWriteTimeUtc_ShouldSetLastWriteTimeUtcOfFileInMemoryFileSystem()
+        {
+            var lastWriteTime = DateTime.Now.AddHours(-4);
+            var fileData = new MockFileData("Demo text content") { LastWriteTime = lastWriteTime };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            var newUtcTime = DateTime.UtcNow;
+            fileInfo.LastWriteTime = newUtcTime;
+
+            Assert.AreEqual(newUtcTime, fileInfo.LastWriteTime);
+        }
+
+        [Test]
+        public void MockFileInfo_GetExtension_ShouldReturnExtension()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
+
+            var result = fileInfo.Extension;
+
+            Assert.AreEqual(".txt", result);
+        }
+
+        [Test]
+        public void MockFileInfo_GetExtensionWithoutExtension_ShouldReturnEmptyString()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a"));
+
+            var result = fileInfo.Extension;
+
+            Assert.AreEqual(string.Empty, result);
+        }
+
+        [Test]
+        public void MockFileInfo_GetDirectoryName_ShouldReturnCompleteDirectoryPath()
+        {
+            var fileInfo = new MockFileInfo(new MockFileSystem(), XFS.Path(@"c:\temp\level1\level2\file.txt"));
+
+            var result = fileInfo.DirectoryName;
+
+            Assert.AreEqual(XFS.Path(@"c:\temp\level1\level2"), result);
+        }
+
+        [Test]
+        public void MockFileInfo_GetDirectory_ShouldReturnDirectoryInfoWithCorrectPath()
+        {
+            var fileInfo = new MockFileInfo(new MockFileSystem(), XFS.Path(@"c:\temp\level1\level2\file.txt"));
+
+            var result = fileInfo.Directory;
+
+            Assert.AreEqual(XFS.Path(@"c:\temp\level1\level2"), result.FullName);
+        }
+
+        [Test]
+        public void MockFileInfo_OpenRead_ShouldReturnByteContentOfFile()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file.txt"), new MockFileData(new byte[] { 1, 2 }));
+            var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file.txt"));
+
+            byte[] result = new byte[2];
+            using (var stream = fileInfo.OpenRead())
+            {
+                stream.Read(result, 0, 2);
+            }
+
+            Assert.AreEqual(new byte[] { 1, 2 }, result);
+        }
+
+        [Test]
+        public void MockFileInfo_OpenText_ShouldReturnStringContentOfFile()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file.txt"), new MockFileData(@"line 1\r\nline 2"));
+            var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file.txt"));
+
+            string result;
+            using (var streamReader = fileInfo.OpenText())
+            {
+                result = streamReader.ReadToEnd();
+            }
+
+            Assert.AreEqual(@"line 1\r\nline 2", result);
+        }
+
+        [Test]
+        public void MockFileInfo_MoveTo_NonExistentDestination_ShouldUpdateFileInfoDirectoryAndFullName()
+        {
+            var fileSystem = new MockFileSystem();
+            var sourcePath = XFS.Path(@"c:\temp\file.txt");
+            var destinationFolder = XFS.Path(@"c:\temp2");
+            var destinationPath = XFS.Path(destinationFolder + @"\file.txt");
+            fileSystem.AddFile(sourcePath, new MockFileData("1"));
+            var fileInfo = fileSystem.FileInfo.FromFileName(sourcePath);
+            fileSystem.AddDirectory(destinationFolder);
+
+            fileInfo.MoveTo(destinationPath);
+
+            Assert.AreEqual(fileInfo.DirectoryName, destinationFolder);
+            Assert.AreEqual(fileInfo.FullName, destinationPath);
+        }
+
+        [Test]
+        public void MockFileInfo_MoveTo_NonExistentDestinationFolder_ShouldThrowDirectoryNotFoundException()
+        {
+            var fileSystem = new MockFileSystem();
+            var sourcePath = XFS.Path(@"c:\temp\file.txt");
+            var destinationPath = XFS.Path(@"c:\temp2\file.txt");
+            fileSystem.AddFile(sourcePath, new MockFileData("1"));
+            var fileInfo = fileSystem.FileInfo.FromFileName(sourcePath);
+
+            Assert.Throws<DirectoryNotFoundException>(() => fileInfo.MoveTo(destinationPath));
+        }
+
+        [Test]
+        public void MockFileInfo_MoveTo_ExistingDestination_ShouldThrowExceptionAboutFileAlreadyExisting()
+        {
+            var fileSystem = new MockFileSystem();
+            var sourcePath = XFS.Path(@"c:\temp\file.txt");
+            var destinationPath = XFS.Path(@"c:\temp2\file.txt");
+            fileSystem.AddFile(sourcePath, new MockFileData("1"));
+            var fileInfo = fileSystem.FileInfo.FromFileName(sourcePath);
+            fileSystem.AddFile(destinationPath, new MockFileData("2"));
+
+            Assert.Throws<IOException>(() => fileInfo.MoveTo(destinationPath));
+        }
+
+        [Test]
+        public void MockFileInfo_MoveTo_SameSourceAndTargetIsANoOp()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file.txt"), new MockFileData(@"line 1\r\nline 2"));
+            var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file.txt"));
+            string destination = XFS.Path(XFS.Path(@"c:\temp\file.txt"));
+
+            fileInfo.MoveTo(destination);
+
+            Assert.AreEqual(fileInfo.FullName, destination);
+            Assert.True(fileInfo.Exists);
+        }
+
+        [Test]
+        public void MockFileInfo_MoveTo_SameSourceAndTargetThrowsExceptionIfSourceDoesntExist()
+        {
+            var fileSystem = new MockFileSystem();
+            var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file.txt"));
+            string destination = XFS.Path(XFS.Path(@"c:\temp\file.txt"));
+
+            TestDelegate action = () => fileInfo.MoveTo(destination);
+
+            Assert.Throws<FileNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockFileInfo_MoveTo_ThrowsExceptionIfSourceDoesntExist()
+        {
+            var fileSystem = new MockFileSystem();
+            var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file.txt"));
+            string destination = XFS.Path(XFS.Path(@"c:\temp\file2.txt"));
+
+            TestDelegate action = () => fileInfo.MoveTo(destination);
+
+            Assert.Throws<FileNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockFileInfo_CopyTo_ThrowsExceptionIfSourceDoesntExist()
+        {
+            var fileSystem = new MockFileSystem();
+            var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file.txt"));
+            string destination = XFS.Path(XFS.Path(@"c:\temp\file2.txt"));
+
+            TestDelegate action = () => fileInfo.CopyTo(destination);
+
+            Assert.Throws<FileNotFoundException>(action);
+        }
+
+#if NET40
+        [Test]
+        public void MockFileInfo_Replace_ShouldReplaceFileContents()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path1 = XFS.Path(@"c:\temp\file1.txt");
+            var path2 = XFS.Path(@"c:\temp\file2.txt");
+            fileSystem.AddFile(path1, new MockFileData("1"));
+            fileSystem.AddFile(path2, new MockFileData("2"));
+            var fileInfo1 = fileSystem.FileInfo.FromFileName(path1);
+            var fileInfo2 = fileSystem.FileInfo.FromFileName(path2);
+
+            // Act
+            fileInfo1.Replace(path2, null);
+
+            Assert.AreEqual("1", fileInfo2.OpenText().ReadToEnd());
+        }
+
+        [Test]
+        public void MockFileInfo_Replace_ShouldCreateBackup()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path1 = XFS.Path(@"c:\temp\file1.txt");
+            var path2 = XFS.Path(@"c:\temp\file2.txt");
+            var path3 = XFS.Path(@"c:\temp\file3.txt");
+            fileSystem.AddFile(path1, new MockFileData("1"));
+            fileSystem.AddFile(path2, new MockFileData("2"));
+            var fileInfo1 = fileSystem.FileInfo.FromFileName(path1);
+            var fileInfo3 = fileSystem.FileInfo.FromFileName(path3);
+
+            // Act
+            fileInfo1.Replace(path2, path3);
+
+            Assert.AreEqual("2", fileInfo3.OpenText().ReadToEnd());
+        }
+
+        [Test]
+        public void MockFileInfo_Replace_ShouldThrowIfDirectoryOfBackupPathDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path1 = XFS.Path(@"c:\temp\file1.txt");
+            var path2 = XFS.Path(@"c:\temp\file2.txt");
+            var path3 = XFS.Path(@"c:\temp\subdirectory\file3.txt");
+            fileSystem.AddFile(path1, new MockFileData("1"));
+            fileSystem.AddFile(path2, new MockFileData("2"));
+            var fileInfo1 = fileSystem.FileInfo.FromFileName(path1);
+
+            // Act
+            Assert.Throws<DirectoryNotFoundException>(() => fileInfo1.Replace(path2, path3));
+        }
+
+        [Test]
+        public void MockFileInfo_Replace_ShouldReturnDestinationFileInfo()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path1 = XFS.Path(@"c:\temp\file1.txt");
+            var path2 = XFS.Path(@"c:\temp\file2.txt");
+            fileSystem.AddFile(path1, new MockFileData("1"));
+            fileSystem.AddFile(path2, new MockFileData("2"));
+            var fileInfo1 = fileSystem.FileInfo.FromFileName(path1);
+            var fileInfo2 = fileSystem.FileInfo.FromFileName(path2);
+
+            // Act
+            var result = fileInfo1.Replace(path2, null);
+
+            Assert.AreEqual(fileInfo2.FullName, result.FullName);
+        }
+
+        [Test]
+        public void MockFileInfo_Replace_ShouldThrowIfSourceFileDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path1 = XFS.Path(@"c:\temp\file1.txt");
+            var path2 = XFS.Path(@"c:\temp\file2.txt");
+            fileSystem.AddFile(path2, new MockFileData("1"));
+            var fileInfo = fileSystem.FileInfo.FromFileName(path1);
+
+            Assert.Throws<FileNotFoundException>(() => fileInfo.Replace(path2, null));
+        }
+
+        [Test]
+        public void MockFileInfo_Replace_ShouldThrowIfDestinationFileDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path1 = XFS.Path(@"c:\temp\file1.txt");
+            var path2 = XFS.Path(@"c:\temp\file2.txt");
+            fileSystem.AddFile(path1, new MockFileData("1"));
+            var fileInfo = fileSystem.FileInfo.FromFileName(path1);
+
+            Assert.Throws<FileNotFoundException>(() => fileInfo.Replace(path2, null));
+        }
+#endif
+    }
+}

--- a/tests/MockFileMoveTests.cs
+++ b/tests/MockFileMoveTests.cs
@@ -1,0 +1,366 @@
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using Collections.Generic;
+    using Linq;
+    using NUnit.Framework;
+    using XFS = MockUnixSupport;
+
+    public class MockFileMoveTests
+    {
+        [Test]
+        public void MockFile_Move_ShouldMoveFileWithinMemoryFileSystem()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            string sourceFileContent = "this is some content";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {sourceFilePath, new MockFileData(sourceFileContent)},
+                {XFS.Path(@"c:\somethingelse\dummy.txt"), new MockFileData(new byte[] {0})}
+            });
+
+            string destFilePath = XFS.Path(@"c:\somethingelse\demo1.txt");
+
+            fileSystem.File.Move(sourceFilePath, destFilePath);
+
+            Assert.That(fileSystem.FileExists(destFilePath), Is.True);
+            Assert.That(fileSystem.GetFile(destFilePath).TextContents, Is.EqualTo(sourceFileContent));
+            Assert.That(fileSystem.FileExists(sourceFilePath), Is.False);
+        }
+
+        [Test]
+        public void MockFile_Move_SameSourceAndTargetIsANoOp()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            string sourceFileContent = "this is some content";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {sourceFilePath, new MockFileData(sourceFileContent)},
+                {XFS.Path(@"c:\somethingelse\dummy.txt"), new MockFileData(new byte[] {0})}
+            });
+
+            string destFilePath = XFS.Path(@"c:\somethingelse\demo.txt");
+
+            fileSystem.File.Move(sourceFilePath, destFilePath);
+
+            Assert.That(fileSystem.FileExists(destFilePath), Is.True);
+            Assert.That(fileSystem.GetFile(destFilePath).TextContents, Is.EqualTo(sourceFileContent));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowIOExceptionWhenTargetAlreadyExists()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            string sourceFileContent = "this is some content";
+            string destFilePath = XFS.Path(@"c:\somethingelse\demo1.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {sourceFilePath, new MockFileData(sourceFileContent)},
+                {destFilePath, new MockFileData(sourceFileContent)}
+            });
+
+            var exception = Assert.Throws<IOException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+
+            Assert.That(exception.Message, Is.EqualTo("A file can not be created if it already exists."));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowArgumentNullExceptionWhenSourceIsNull_Message()
+        {
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Move(null, destFilePath));
+
+            Assert.That(exception.Message, Does.StartWith("File name cannot be null."));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowArgumentNullExceptionWhenSourceIsNull_ParamName()
+        {
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Move(null, destFilePath));
+
+            Assert.That(exception.ParamName, Is.EqualTo("sourceFileName"));
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+        public void MockFile_Move_ShouldThrowArgumentExceptionWhenSourceFileNameContainsInvalidChars_Message()
+        {
+            var destFilePath = @"c:\something\demo.txt";
+            var fileSystem = new MockFileSystem();
+            var excludeChars = Shared.SpecialInvalidPathChars(fileSystem);
+
+            foreach (var invalidChar in fileSystem.Path.GetInvalidFileNameChars().Except(excludeChars))
+            {
+                var sourceFilePath = @"c:\something\demo.txt" + invalidChar;
+
+                var exception =
+                    Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+
+                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
+                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+            }
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+        public void MockFile_Move_ShouldThrowArgumentExceptionWhenSourcePathContainsInvalidChars_Message()
+        {
+            var destFilePath = @"c:\something\demo.txt";
+            var fileSystem = new MockFileSystem();
+
+            foreach (var invalidChar in fileSystem.Path.GetInvalidPathChars())
+            {
+                var sourceFilePath = @"c:\some" + invalidChar + @"thing\demo.txt";
+
+                var exception =
+                    Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+
+                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
+                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+            }
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+        public void MockFile_Move_ShouldThrowArgumentExceptionWhenTargetPathContainsInvalidChars_Message()
+        {
+            var sourceFilePath = @"c:\something\demo.txt";
+            var fileSystem = new MockFileSystem();
+
+            foreach (var invalidChar in fileSystem.Path.GetInvalidPathChars())
+            {
+                var destFilePath = @"c:\some" + invalidChar + @"thing\demo.txt";
+
+                var exception =
+                    Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+
+                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
+                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+            }
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+        public void MockFile_Move_ShouldThrowArgumentExceptionWhenTargetFileNameContainsInvalidChars_Message()
+        {
+            var sourceFilePath = @"c:\something\demo.txt";
+            var fileSystem = new MockFileSystem();
+            var excludeChars = Shared.SpecialInvalidPathChars(fileSystem);
+
+            foreach (var invalidChar in fileSystem.Path.GetInvalidFileNameChars().Except(excludeChars))
+            {
+                var destFilePath = @"c:\something\demo.txt" + invalidChar;
+
+                var exception =
+                    Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+
+                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
+                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+            }
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void MockFile_Move_ShouldThrowNotSupportedExceptionWhenSourcePathContainsInvalidUseOfDriveSeparator()
+        {
+            var badSourcePath = @"C::\something\demo.txt";
+            var destinationPath = @"C:\elsewhere\demo.txt";
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.Move(badSourcePath, destinationPath);
+
+            Assert.Throws<NotSupportedException>(action);
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void MockFile_Move_ShouldThrowNotSupportedExceptionWhenSourcePathContainsInvalidDriveLetter()
+        {
+            var badSourcePath = @"0:\something\demo.txt";
+            var destinationPath = @"C:\elsewhere\demo.txt";
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.Move(badSourcePath, destinationPath);
+
+            Assert.Throws<NotSupportedException>(action);
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void MockFile_Move_ShouldThrowNotSupportedExceptionWhenDestinationPathContainsInvalidUseOfDriveSeparator()
+        {
+            var sourcePath = @"C:\something\demo.txt";
+            var badDestinationPath = @"C:\elsewhere:\demo.txt";
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.Move(sourcePath, badDestinationPath);
+
+            Assert.Throws<NotSupportedException>(action);
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void MockFile_Move_ShouldThrowNotSupportedExceptionWhenDestinationPathContainsInvalidDriveLetter()
+        {
+            var sourcePath = @"C:\something\demo.txt";
+            var badDestinationPath = @"^:\elsewhere\demo.txt";
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.Move(sourcePath, badDestinationPath);
+
+            Assert.Throws<NotSupportedException>(action);
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowArgumentExceptionWhenSourceIsEmpty_Message()
+        {
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(string.Empty, destFilePath));
+
+            Assert.That(exception.Message, Does.StartWith("Empty file name is not legal."));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowArgumentExceptionWhenSourceIsEmpty_ParamName() {
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(string.Empty, destFilePath));
+
+            Assert.That(exception.ParamName, Is.EqualTo("sourceFileName"));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowArgumentExceptionWhenSourceIsStringOfBlanks()
+        {
+            string sourceFilePath = "   ";
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+
+            Assert.That(exception.Message, Does.StartWith("The path is not of a legal form."));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowArgumentNullExceptionWhenTargetIsNull_Message()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Move(sourceFilePath, null));
+
+            Assert.That(exception.Message, Does.StartWith("File name cannot be null."));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowArgumentNullExceptionWhenTargetIsNull_ParamName() {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Move(sourceFilePath, null));
+
+            Assert.That(exception.ParamName, Is.EqualTo("destFileName"));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowArgumentExceptionWhenTargetIsStringOfBlanks()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            string destFilePath = "   ";
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+
+            Assert.That(exception.Message, Does.StartWith("The path is not of a legal form."));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowArgumentExceptionWhenTargetIsEmpty_Message()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, string.Empty));
+
+            Assert.That(exception.Message, Does.StartWith("Empty file name is not legal."));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowArgumentExceptionWhenTargetIsEmpty_ParamName()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, string.Empty));
+
+            Assert.That(exception.ParamName, Is.EqualTo("destFileName"));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowFileNotFoundExceptionWhenSourceDoesNotExist_Message()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            string destFilePath = XFS.Path(@"c:\something\demo1.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<FileNotFoundException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+
+            Assert.That(exception.Message, Is.EqualTo("The file \"" + XFS.Path("c:\\something\\demo.txt") + "\" could not be found."));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowFileNotFoundExceptionWhenSourceDoesNotExist_FileName()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            string destFilePath = XFS.Path(@"c:\something\demo1.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<FileNotFoundException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+
+            Assert.That(exception.FileName, Is.EqualTo(XFS.Path(@"c:\something\demo.txt")));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowDirectoryNotFoundExceptionWhenSourcePathDoesNotExist_Message()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            string destFilePath = XFS.Path(@"c:\somethingelse\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {sourceFilePath, new MockFileData(new byte[] {0})}
+            });
+
+            Assert.That(() => fileSystem.File.Move(sourceFilePath, destFilePath),
+                Throws.InstanceOf<DirectoryNotFoundException>().With.Message.StartsWith(@"Could not find a part of the path"));
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowExceptionWhenSourceDoesNotExist()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.Move(sourceFilePath, XFS.Path(@"c:\something\demo2.txt"));
+
+            Assert.Throws<FileNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockFile_Move_ShouldThrowExceptionWhenSourceDoesNotExist_EvenWhenCopyingToItself()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.Move(sourceFilePath, XFS.Path(@"c:\something\demo.txt"));
+
+            Assert.Throws<FileNotFoundException>(action);
+        }
+    }
+}

--- a/tests/MockFileOpenTests.cs
+++ b/tests/MockFileOpenTests.cs
@@ -1,0 +1,262 @@
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using Collections.Generic;
+
+    using NUnit.Framework;
+
+    using XFS = MockUnixSupport;
+
+    public class MockFileOpenTests {
+        [Test]
+        public void MockFile_Open_ThrowsOnCreateNewWithExistingFile()
+        {
+            string filepath = XFS.Path(@"c:\something\already\exists.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData> 
+            {
+                { filepath, new MockFileData("I'm here") }
+            });
+
+            Assert.Throws<IOException>(() => filesystem.File.Open(filepath, FileMode.CreateNew));
+        }
+
+        [Test]
+        public void MockFile_Open_ThrowsOnOpenWithMissingFile()
+        {
+            string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+
+            Assert.Throws<FileNotFoundException>(() => filesystem.File.Open(filepath, FileMode.Open));
+        }
+
+        [Test]
+        public void MockFile_Open_ThrowsOnTruncateWithMissingFile()
+        {
+            string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+
+            Assert.Throws<FileNotFoundException>(() => filesystem.File.Open(filepath, FileMode.Truncate));
+        }
+
+        [Test]
+        public void MockFile_Open_CreatesNewFileFileOnCreate()
+        {
+            string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            filesystem.AddDirectory(XFS.Path(@"c:\something\doesnt"));
+
+            var stream = filesystem.File.Open(filepath, FileMode.Create);
+
+            Assert.That(filesystem.File.Exists(filepath), Is.True);
+            Assert.That(stream.Position, Is.EqualTo(0));
+            Assert.That(stream.Length, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void MockFile_Open_CreatesNewFileFileOnCreateNew()
+        {
+            string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            filesystem.AddDirectory(XFS.Path(@"c:\something\doesnt"));
+
+            var stream = filesystem.File.Open(filepath, FileMode.CreateNew);
+
+            Assert.That(filesystem.File.Exists(filepath), Is.True);
+            Assert.That(stream.Position, Is.EqualTo(0));
+            Assert.That(stream.Length, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void MockFile_Open_OpensExistingFileOnAppend()
+        {
+            string filepath = XFS.Path(@"c:\something\does\exist.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { filepath, new MockFileData("I'm here") }
+            });
+
+            var stream = filesystem.File.Open(filepath, FileMode.Append);
+            var file = filesystem.GetFile(filepath);
+            
+            Assert.That(stream.Position, Is.EqualTo(file.Contents.Length));
+            Assert.That(stream.Length, Is.EqualTo(file.Contents.Length));
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            byte[] data;
+            using (var br = new BinaryReader(stream))
+                data = br.ReadBytes((int)stream.Length);
+
+            CollectionAssert.AreEqual(file.Contents, data);
+        }
+
+        [Test]
+        public void MockFile_Open_OpensExistingFileOnTruncate()
+        {
+            string filepath = XFS.Path(@"c:\something\does\exist.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { filepath, new MockFileData("I'm here") }
+            });
+
+            var stream = filesystem.File.Open(filepath, FileMode.Truncate);
+            var file = filesystem.GetFile(filepath);
+
+            Assert.That(stream.Position, Is.EqualTo(0));
+            Assert.That(stream.Length, Is.EqualTo(0));
+            Assert.That(file.Contents.Length, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void MockFile_Open_OpensExistingFileOnOpen()
+        {
+            string filepath = XFS.Path(@"c:\something\does\exist.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { filepath, new MockFileData("I'm here") }
+            });
+
+            var stream = filesystem.File.Open(filepath, FileMode.Open);
+            var file = filesystem.GetFile(filepath);
+
+            Assert.That(stream.Position, Is.EqualTo(0));
+            Assert.That(stream.Length, Is.EqualTo(file.Contents.Length));
+
+            byte[] data;
+            using (var br = new BinaryReader(stream))
+                data = br.ReadBytes((int)stream.Length);
+
+            CollectionAssert.AreEqual(file.Contents, data);
+        }
+
+        [Test]
+        public void MockFile_Open_OpensExistingFileOnOpenOrCreate()
+        {
+            string filepath = XFS.Path(@"c:\something\does\exist.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { filepath, new MockFileData("I'm here") }
+            });
+
+            var stream = filesystem.File.Open(filepath, FileMode.OpenOrCreate);
+            var file = filesystem.GetFile(filepath);
+
+            Assert.That(stream.Position, Is.EqualTo(0));
+            Assert.That(stream.Length, Is.EqualTo(file.Contents.Length));
+
+            byte[] data;
+            using (var br = new BinaryReader(stream))
+                data = br.ReadBytes((int)stream.Length);
+
+            CollectionAssert.AreEqual(file.Contents, data);
+        }
+
+        [Test]
+        public void MockFile_Open_CreatesNewFileOnOpenOrCreate()
+        {
+            string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            filesystem.AddDirectory(XFS.Path(@"c:\something\doesnt"));
+
+            var stream = filesystem.File.Open(filepath, FileMode.OpenOrCreate);
+
+            Assert.That(filesystem.File.Exists(filepath), Is.True);
+            Assert.That(stream.Position, Is.EqualTo(0));
+            Assert.That(stream.Length, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void MockFile_Open_OverwritesExistingFileOnCreate()
+        {
+            string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { filepath, new MockFileData("I'm here") }
+            });
+
+            var stream = filesystem.File.Open(filepath, FileMode.Create);
+            var file = filesystem.GetFile(filepath);
+
+            Assert.That(stream.Position, Is.EqualTo(0));
+            Assert.That(stream.Length, Is.EqualTo(0));
+            Assert.That(file.Contents.Length, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void MockFile_OpenText_ShouldRetainLastWriteTime()
+        {
+            // Arrange
+            var fs = new MockFileSystem();
+            string filepath = XFS.Path(@"C:\TestData\test.txt");
+            var file = new MockFileData(@"I'm here");
+            var lastWriteTime = new DateTime(2012, 03, 21);
+            file.LastWriteTime = lastWriteTime;
+            fs.AddFile(filepath, file);
+
+            // Act
+            using (var reader = fs.File.OpenText(filepath))
+            {
+                reader.ReadLine();
+            }
+
+            // Assert
+            Assert.AreEqual(lastWriteTime, fs.FileInfo.FromFileName(filepath).LastWriteTime);
+        }
+
+        [Test]
+        public void MockFile_OpenText_ShouldRetainLastAccessTime()
+        {
+            // Arrange
+            var fs = new MockFileSystem();
+            string filepath = XFS.Path(@"C:\TestData\test.txt");
+            var file = new MockFileData(@"I'm here");
+            var lastAccessTime = new DateTime(2012, 03, 21);
+            file.LastAccessTime = lastAccessTime;
+            fs.AddFile(filepath, file);
+
+            // Act
+            using (var reader = fs.File.OpenText(filepath))
+            {
+                reader.ReadLine();
+            }
+
+            // Assert
+            Assert.AreEqual(lastAccessTime, fs.FileInfo.FromFileName(filepath).LastAccessTime);
+        }
+
+        [Test]
+        public void MockFile_OpenText_ShouldRetainCreationTime()
+        {
+            // Arrange
+            var fs = new MockFileSystem();
+            string filepath = XFS.Path(@"C:\TestData\test.txt");
+            var file = new MockFileData(@"I'm here");
+            var creationTime = new DateTime(2012, 03, 21);
+            file.CreationTime = creationTime;
+            fs.AddFile(filepath, file);
+
+            // Act
+            using (var reader = fs.File.OpenText(filepath))
+            {
+                reader.ReadLine();
+            }
+
+            // Assert
+            Assert.AreEqual(creationTime, fs.FileInfo.FromFileName(filepath).CreationTime);
+        }
+
+        [Test]
+        public void MockFile_Open_ShouldThrowDirectoryNotFoundExceptionIfFileModeCreateAndParentPathDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.Open("C:\\Path\\NotFound.ext", FileMode.Create);
+
+            // Assert
+            Assert.IsFalse(fileSystem.Directory.Exists("C:\\path"));
+            var exception = Assert.Throws<DirectoryNotFoundException>(action);
+            Assert.That(exception.Message, Does.StartWith("Could not find a part of the path"));
+        }
+    }
+}

--- a/tests/MockFileReadAllBytesTests.cs
+++ b/tests/MockFileReadAllBytesTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    public class MockFileReadAllBytesTests
+    {
+        [Test]
+        public void MockFile_ReadAllBytes_ShouldReturnOriginalByteData()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            var result = file.ReadAllBytes(XFS.Path(@"c:\something\other.gif"));
+
+            CollectionAssert.AreEqual(
+                new byte[] { 0x21, 0x58, 0x3f, 0xa9 },
+                result);
+        }
+
+        [Test]
+        public void MockFile_ReadAllBytes_ShouldReturnDataSavedByWriteAllBytes()
+        {
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+            var fileContent = new byte[] { 1, 2, 3, 4 };
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+
+            fileSystem.File.WriteAllBytes(path, fileContent);
+
+            Assert.AreEqual(fileContent, fileSystem.File.ReadAllBytes(path));
+        }
+
+        [Test]
+        public void MockFile_ReadAllBytes_ShouldThrowFileNotFoundExceptionIfFileDoesNotExist()
+        {
+            var fileSystem = new MockFileSystem();
+            var file = new MockFile(fileSystem);
+
+            TestDelegate action = () => file.ReadAllBytes(@"C:\a.txt");
+
+            Assert.Throws<FileNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockFile_ReadAllBytes_ShouldTolerateAltDirectorySeparatorInPath()
+        {
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path("C:" + fileSystem.Path.DirectorySeparatorChar + "test.dat");
+            var altPath = XFS.Path("C:" + fileSystem.Path.AltDirectorySeparatorChar + "test.dat");
+            var data = new byte[] { 0x12, 0x34, 0x56, 0x78 };
+
+            fileSystem.AddFile(path, new MockFileData(data));
+
+            Assert.AreEqual(data, fileSystem.File.ReadAllBytes(altPath));
+        }
+    }
+}

--- a/tests/MockFileReadAllLinesTests.cs
+++ b/tests/MockFileReadAllLinesTests.cs
@@ -1,0 +1,55 @@
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using Collections.Generic;
+
+    using NUnit.Framework;
+
+    using Text;
+
+    using XFS = MockUnixSupport;
+
+    public class MockFileReadAllLinesTests {
+        [Test]
+        public void MockFile_ReadAllLines_ShouldReturnOriginalTextData()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo\r\ntext\ncontent\rvalue") },
+                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var result = file.ReadAllLines(XFS.Path(@"c:\something\demo.txt"));
+
+            // Assert
+            CollectionAssert.AreEqual(
+                new[] { "Demo", "text", "content", "value" },
+                result);
+        }
+
+        [Test]
+        public void MockFile_ReadAllLines_ShouldReturnOriginalDataWithCustomEncoding()
+        {
+            // Arrange
+            string text = "Hello\r\nthere\rBob\nBob!";
+            var encodedText = Encoding.BigEndianUnicode.GetBytes(text);
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData(encodedText) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var result = file.ReadAllLines(XFS.Path(@"c:\something\demo.txt"), Encoding.BigEndianUnicode);
+
+            // Assert
+            CollectionAssert.AreEqual(
+                new [] { "Hello", "there", "Bob", "Bob!" },
+                result);
+        }
+    }
+}

--- a/tests/MockFileReadLinesTests.cs
+++ b/tests/MockFileReadLinesTests.cs
@@ -1,0 +1,55 @@
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using Collections.Generic;
+
+    using NUnit.Framework;
+
+    using Text;
+
+    using XFS = MockUnixSupport;
+
+    public class MockFileReadLinesTests {
+        [Test]
+        public void MockFile_ReadLines_ShouldReturnOriginalTextData()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo\r\ntext\ncontent\rvalue") },
+                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var result = file.ReadLines(XFS.Path(@"c:\something\demo.txt"));
+
+            // Assert
+            CollectionAssert.AreEqual(
+                new[] { "Demo", "text", "content", "value" },
+                result);
+        }
+
+        [Test]
+        public void MockFile_ReadLines_ShouldReturnOriginalDataWithCustomEncoding()
+        {
+            // Arrange
+            string text = "Hello\r\nthere\rBob\nBob!";
+            var encodedText = Encoding.BigEndianUnicode.GetBytes(text);
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData(encodedText) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var result = file.ReadLines(XFS.Path(@"c:\something\demo.txt"), Encoding.BigEndianUnicode);
+
+            // Assert
+            CollectionAssert.AreEqual(
+                new [] { "Hello", "there", "Bob", "Bob!" },
+                result);
+        }
+    }
+}

--- a/tests/MockFileSetAccessControlTests.cs
+++ b/tests/MockFileSetAccessControlTests.cs
@@ -1,0 +1,66 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using System.Security.AccessControl;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    [WindowsOnly(WindowsSpecifics.AccessControlLists)]
+    public class MockFileSetAccessControlTests
+    {
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockFile_SetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var fileSecurity = new FileSecurity();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.SetAccessControl(path, fileSecurity);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockFile_SetAccessControl_ShouldThrowFileNotFoundExceptionIfFileDoesNotExistInMockData()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var expectedFileName = XFS.Path(@"c:\a.txt");
+            var fileSecurity = new FileSecurity();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.SetAccessControl(expectedFileName, fileSecurity);
+
+            // Assert
+            var exception = Assert.Throws<FileNotFoundException>(action);
+            Assert.That(exception.FileName, Is.EqualTo(expectedFileName));
+        }
+
+        [Test]
+        public void MockFile_SetAccessControl_ShouldSetAccessControlOfFileData()
+        {
+            // Arrange
+            var filePath = XFS.Path(@"c:\a.txt");
+            var fileData = new MockFileData("Test content");
+
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { filePath, fileData }
+            });
+
+            // Act
+            var expectedAccessControl = new FileSecurity();
+            expectedAccessControl.SetAccessRuleProtection(false, false);
+            fileSystem.File.SetAccessControl(filePath, expectedAccessControl);
+
+            // Assert
+            var accessControl = fileSystem.File.GetAccessControl(filePath);
+            Assert.That(accessControl, Is.EqualTo(expectedAccessControl));
+        }
+    }
+}

--- a/tests/MockFileSetAttributesTests.cs
+++ b/tests/MockFileSetAttributesTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockFileSetAttributesTests
+    {
+        [Test]
+        public void MockFile_SetAttributes_ShouldSetAttributesOnFile()
+        {
+            var path = XFS.Path(@"c:\something\demo.txt");
+            var filedata = new MockFileData("test");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {path, filedata},
+            });
+
+            fileSystem.File.SetAttributes(path, FileAttributes.Hidden);
+
+            var attributes = fileSystem.File.GetAttributes(path);
+            Assert.That(attributes, Is.EqualTo(FileAttributes.Hidden));
+        }
+
+        [Test]
+        public void MockFile_SetAttributes_ShouldSetAttributesOnDirectory()
+        {
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path(@"c:\something");
+            fileSystem.AddDirectory(path);
+            var directoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(path);
+            directoryInfo.Attributes = FileAttributes.Directory | FileAttributes.Normal;
+
+            fileSystem.File.SetAttributes(path, FileAttributes.Directory | FileAttributes.Hidden);
+
+            var attributes = fileSystem.File.GetAttributes(path);
+            Assert.That(attributes, Is.EqualTo(FileAttributes.Directory | FileAttributes.Hidden));
+        }
+
+        [Test]
+        [TestCase("", FileAttributes.Normal)]
+        [TestCase("   ", FileAttributes.Normal)]
+        public void MockFile_SetAttributes_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path, FileAttributes attributes)
+        {
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.SetAttributes(path, attributes);
+
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
+        public void MockFile_SetAttributes_ShouldThrowFileNotFoundExceptionIfMissingDirectory()
+        {
+            var path = XFS.Path(@"C:\something");
+            var attributes = FileAttributes.Normal;
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.SetAttributes(path, attributes);
+
+            var exception = Assert.Throws<FileNotFoundException>(action);
+            Assert.That(exception.FileName, Is.EqualTo(path));
+        }
+    }
+}

--- a/tests/MockFileStreamFactoryTests.cs
+++ b/tests/MockFileStreamFactoryTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework; 
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockFileStreamFactoryTests
+    {
+        [Test]
+        [TestCase(FileMode.Create)]
+        [TestCase(FileMode.Append)]
+        public void MockFileStreamFactory_CreateForExistingFile_ShouldReturnStream(FileMode fileMode)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\existing.txt", MockFileData.NullObject }
+            });
+
+            var fileStreamFactory = new MockFileStreamFactory(fileSystem);
+
+            // Act
+            var result = fileStreamFactory.Create(@"c:\existing.txt", fileMode);
+
+            // Assert
+            Assert.IsNotNull(result);
+        }
+
+        [Test]
+        [TestCase(FileMode.Create)]
+        [TestCase(FileMode.Append)]
+        public void MockFileStreamFactory_CreateForNonExistingFile_ShouldReturnStream(FileMode fileMode)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var fileStreamFactory = new MockFileStreamFactory(fileSystem);
+
+            // Act
+            var result = fileStreamFactory.Create(@"c:\not_existing.txt", fileMode);
+
+            // Assert
+            Assert.IsNotNull(result);
+        }
+    }
+}

--- a/tests/MockFileStreamTests.cs
+++ b/tests/MockFileStreamTests.cs
@@ -1,0 +1,110 @@
+﻿namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using System.Collections.Generic;
+
+    using NUnit.Framework;
+
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    public class MockFileStreamTests
+    {
+        [Test]
+        public void MockFileStream_Flush_WritesByteToFile()
+        {
+            // Arrange
+            var filepath = XFS.Path(@"c:\something\foo.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var cut = new MockFileStream(filesystem, filepath, MockFileStream.StreamType.WRITE);
+
+            // Act
+            cut.WriteByte(255);
+            cut.Flush();
+
+            // Assert
+            CollectionAssert.AreEqual(new byte[]{255}, filesystem.GetFile(filepath).Contents);
+        }
+
+        [Test]
+        public void MockFileStream_Dispose_ShouldNotResurrectFile()
+        {
+            // path in this test case is a subject to Directory.GetParent(path) Linux issue
+            // https://github.com/System-IO-Abstractions/System.IO.Abstractions/issues/395
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path("C:\\some_folder\\test");
+            var directory = fileSystem.Path.GetDirectoryName(path);
+            fileSystem.AddFile(path, new MockFileData("Bla"));
+            var stream = fileSystem.File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Delete);
+
+            var fileCount1 = fileSystem.Directory.GetFiles(directory, "*").Length;
+            fileSystem.File.Delete(path);
+            var fileCount2 = fileSystem.Directory.GetFiles(directory, "*").Length;
+            stream.Dispose();
+            var fileCount3 = fileSystem.Directory.GetFiles(directory, "*").Length;
+
+            Assert.AreEqual(1, fileCount1, "File should have existed");
+            Assert.AreEqual(0, fileCount2, "File should have been deleted");
+            Assert.AreEqual(0, fileCount3, "Disposing stream should not have resurrected the file");
+        }
+
+        [Test]
+        public void MockFileStream_Constructor_Reading_Nonexistent_File_Throws_Exception()
+        {
+            // Arrange
+            var nonexistentFilePath = XFS.Path(@"c:\something\foo.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+
+            // Act
+            Assert.Throws<FileNotFoundException>(() => new MockFileStream(filesystem, nonexistentFilePath, MockFileStream.StreamType.READ));
+
+            // Assert - expect an exception
+        }
+
+        [Test]
+        public void MockFileStream_Constructor_ReadTypeNotWritable()
+        {
+            // Arrange
+            var filePath = @"C:\test.txt";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { filePath, new MockFileData("hi") }
+            });
+
+            // Act
+            var stream = new MockFileStream(fileSystem, filePath, MockFileStream.StreamType.READ);
+
+            Assert.IsFalse(stream.CanWrite);
+            Assert.Throws<NotSupportedException>(() => stream.WriteByte(1));
+        }
+
+        [Test]
+        public void MockFileStream_Close_MultipleCallsDontThrow()
+        {
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path("C:\\test");
+            fileSystem.AddFile(path, new MockFileData("Bla"));
+            var stream = fileSystem.File.OpenRead(path);
+
+            // Act
+            stream.Close();
+
+            // Assert
+            Assert.DoesNotThrow(() => stream.Close());
+        }
+
+        [Test]
+        public void MockFileStream_Dispose_MultipleCallsDontThrow()
+        {
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path("C:\\test");
+            fileSystem.AddFile(path, new MockFileData("Bla"));
+            var stream = fileSystem.File.OpenRead(path);
+
+            // Act
+            stream.Dispose();
+
+            // Assert
+            Assert.DoesNotThrow(() => stream.Dispose());
+        }
+    }
+}

--- a/tests/MockFileSystemTests.cs
+++ b/tests/MockFileSystemTests.cs
@@ -1,0 +1,308 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using NUnit.Framework;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockFileSystemTests
+    {
+        [Test]
+        public void MockFileSystem_GetFile_ShouldReturnNullWhenFileIsNotRegistered()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\something\demo.txt", new MockFileData("Demo\r\ntext\ncontent\rvalue") },
+                { @"c:\something\other.gif", new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+
+            var result = fileSystem.GetFile(@"c:\something\else.txt");
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void MockFileSystem_GetFile_ShouldReturnFileRegisteredInConstructor()
+        {
+            var file1 = new MockFileData("Demo\r\ntext\ncontent\rvalue");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\something\demo.txt", file1 },
+                { @"c:\something\other.gif", new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+
+            var result = fileSystem.GetFile(@"c:\something\demo.txt");
+
+            Assert.AreEqual(file1, result);
+        }
+
+        [Test]
+        public void MockFileSystem_GetFile_ShouldReturnFileRegisteredInConstructorWhenPathsDifferByCase()
+        {
+            var file1 = new MockFileData("Demo\r\ntext\ncontent\rvalue");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\something\demo.txt", file1 },
+                { @"c:\something\other.gif", new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+
+            var result = fileSystem.GetFile(@"c:\SomeThing\DEMO.txt");
+
+            Assert.AreEqual(file1, result);
+        }
+
+        [Test]
+        public void MockFileSystem_AddFile_ShouldHandleNullFileDataAsEmpty()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\something\nullish.txt", null }
+            });
+
+            var result = fileSystem.File.ReadAllText(@"c:\SomeThing\nullish.txt");
+
+            Assert.IsEmpty(result, "Null MockFileData should be allowed for and result in an empty file.");
+        }
+
+        [Test]
+        public void MockFileSystem_AddFile_ShouldRepaceExistingFile()
+        {
+            const string path = @"c:\some\file.txt";
+            const string existingContent = "Existing content";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData(existingContent) }
+            });
+            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo(existingContent));
+
+            const string newContent = "New content";
+            fileSystem.AddFile(path, new MockFileData(newContent));
+
+            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo(newContent));
+        }
+#if NET40
+        [Test]
+        public void MockFileSystem_ByDefault_IsSerializable()
+        {
+            var file1 = new MockFileData("Demo\r\ntext\ncontent\rvalue");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\something\demo.txt", file1 },
+                { @"c:\something\other.gif", new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+            var memoryStream = new MemoryStream();
+
+            var serializer = new Runtime.Serialization.Formatters.Binary.BinaryFormatter();
+            serializer.Serialize(memoryStream, fileSystem);
+
+            Assert.That(memoryStream.Length > 0, "Length didn't increase after serialization task.");
+        }
+#endif
+
+        [Test]
+        public void MockFileSystem_AddDirectory_ShouldCreateDirectory()
+        {
+            string baseDirectory = XFS.Path(@"C:\Test");
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.AddDirectory(baseDirectory);
+
+            Assert.IsTrue(fileSystem.Directory.Exists(baseDirectory));
+        }
+
+        [Test]
+        public void MockFileSystem_AddDirectory_ShouldThrowExceptionIfDirectoryIsReadOnly()
+        {
+            string baseDirectory = XFS.Path(@"C:\Test");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(baseDirectory, new MockFileData(string.Empty));
+            fileSystem.File.SetAttributes(baseDirectory, FileAttributes.ReadOnly);
+
+            TestDelegate action = () => fileSystem.AddDirectory(baseDirectory);
+
+            Assert.Throws<UnauthorizedAccessException>(action);
+        }
+
+        [Test]
+        public void MockFileSystem_DriveInfo_ShouldNotThrowAnyException()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\Test"));
+
+            var actualResults = fileSystem.DriveInfo.GetDrives();
+
+            Assert.IsNotNull(actualResults);
+        }
+
+        [Test]
+        public void MockFileSystem_AddFile_ShouldMatchCapitalization_PerfectMatch()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\test"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\LOUD"));
+
+            fileSystem.AddFile(XFS.Path(@"C:\test\file.txt"), "foo");
+            fileSystem.AddFile(XFS.Path(@"C:\LOUD\file.txt"), "foo");
+            fileSystem.AddDirectory(XFS.Path(@"C:\test\SUBDirectory"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\LOUD\SUBDirectory"));
+
+            Assert.Contains(XFS.Path(@"C:\test\file.txt"), fileSystem.AllFiles.ToList());
+            Assert.Contains(XFS.Path(@"C:\LOUD\file.txt"), fileSystem.AllFiles.ToList());
+            Assert.Contains(XFS.Path(@"C:\test\SUBDirectory"), fileSystem.AllDirectories.ToList());
+            Assert.Contains(XFS.Path(@"C:\LOUD\SUBDirectory"), fileSystem.AllDirectories.ToList());
+        }
+
+        [Test]
+        public void MockFileSystem_AddFile_ShouldMatchCapitalization_PartialMatch()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\test\subtest"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\LOUD\SUBLOUD"));
+
+            fileSystem.AddFile(XFS.Path(@"C:\test\SUBTEST\file.txt"), "foo");
+            fileSystem.AddFile(XFS.Path(@"C:\LOUD\subloud\file.txt"), "foo");
+            fileSystem.AddDirectory(XFS.Path(@"C:\test\SUBTEST\SUBDirectory"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\LOUD\subloud\SUBDirectory"));
+
+            Assert.Contains(XFS.Path(@"C:\test\subtest\file.txt"), fileSystem.AllFiles.ToList());
+            Assert.Contains(XFS.Path(@"C:\LOUD\SUBLOUD\file.txt"), fileSystem.AllFiles.ToList());
+            Assert.Contains(XFS.Path(@"C:\test\subtest\SUBDirectory"), fileSystem.AllDirectories.ToList());
+            Assert.Contains(XFS.Path(@"C:\LOUD\SUBLOUD\SUBDirectory"), fileSystem.AllDirectories.ToList());
+        }
+
+        [Test]
+        public void MockFileSystem_AddFile_ShouldMatchCapitalization_PartialMatch_FurtherLeft()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:\test\subtest"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\LOUD\SUBLOUD"));
+
+            fileSystem.AddFile(XFS.Path(@"C:\test\SUBTEST\new\file.txt"), "foo");
+            fileSystem.AddFile(XFS.Path(@"C:\LOUD\subloud\new\file.txt"), "foo");
+            fileSystem.AddDirectory(XFS.Path(@"C:\test\SUBTEST\new\SUBDirectory"));
+            fileSystem.AddDirectory(XFS.Path(@"C:\LOUD\subloud\new\SUBDirectory"));
+
+            Assert.Contains(XFS.Path(@"C:\test\subtest\new\file.txt"), fileSystem.AllFiles.ToList());
+            Assert.Contains(XFS.Path(@"C:\LOUD\SUBLOUD\new\file.txt"), fileSystem.AllFiles.ToList());
+            Assert.Contains(XFS.Path(@"C:\test\subtest\new\SUBDirectory"), fileSystem.AllDirectories.ToList());
+            Assert.Contains(XFS.Path(@"C:\LOUD\SUBLOUD\new\SUBDirectory"), fileSystem.AllDirectories.ToList());
+        }
+
+        [Test]
+        public void MockFileSystem_AddFileFromEmbeddedResource_ShouldAddTheFile()
+        {
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.AddFileFromEmbeddedResource(XFS.Path(@"C:\TestFile.txt"), Assembly.GetExecutingAssembly(), "System.IO.Abstractions.TestingHelpers.Tests.TestFiles.TestFile.txt");
+            var result = fileSystem.GetFile(XFS.Path(@"C:\TestFile.txt"));
+
+            Assert.AreEqual(new UTF8Encoding().GetBytes("This is a test file."), result.Contents);
+        }
+
+        [Test]
+        public void MockFileSystem_AddFilesFromEmbeddedResource_ShouldAddAllTheFiles()
+        {
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.AddFilesFromEmbeddedNamespace(XFS.Path(@"C:\"), Assembly.GetExecutingAssembly(), "System.IO.Abstractions.TestingHelpers.Tests.TestFiles");
+
+            Assert.Contains(XFS.Path(@"C:\TestFile.txt"), fileSystem.AllFiles.ToList());
+            Assert.Contains(XFS.Path(@"C:\SecondTestFile.txt"), fileSystem.AllFiles.ToList());
+        }
+
+        [Test]
+        public void MockFileSystem_RemoveFile_RemovesFiles()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(@"C:\file.txt", new MockFileData("Content"));
+
+            fileSystem.RemoveFile(@"C:\file.txt");
+
+            Assert.False(fileSystem.FileExists(@"C:\file.txt"));
+        }
+
+        [Test]
+        public void MockFileSystem_RemoveFile_ThrowsUnauthorizedAccessExceptionIfFileIsReadOnly()
+        {
+            var path = XFS.Path(@"C:\file.txt");
+            var readOnlyFile = new MockFileData("")
+            {
+                Attributes = FileAttributes.ReadOnly
+            };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, readOnlyFile },
+            });
+
+            TestDelegate action = () => fileSystem.RemoveFile(path);
+
+            Assert.Throws<UnauthorizedAccessException>(action);
+        }
+
+        [Test]
+        public void MockFileSystem_AllNodes_ShouldReturnAllNodes()
+        {
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), MockFileData.NullObject },
+                { XFS.Path(@"c:\something\other.gif"), MockFileData.NullObject },
+                { XFS.Path(@"d:\foobar\"), new MockDirectoryData() },
+                { XFS.Path(@"d:\foo\bar"), new MockDirectoryData( )}
+            });
+            var expectedNodes = new[]
+            {
+                XFS.Path(@"c:\something\demo.txt"),
+                XFS.Path(@"c:\something\other.gif"),
+                XFS.Path(@"d:\foobar"),
+                XFS.Path(@"d:\foo\bar")
+            };
+
+            var result = fileSystem.AllNodes;
+
+            Assert.AreEqual(expectedNodes, result);
+        }
+
+        [Test]
+        [TestCase(@"C:\path")]
+        [TestCase(@"C:\path\")]
+        public void MockFileSystem_AddDirectory_TrailingSlashAllowedButNotRequired(string path)
+        {
+            var fileSystem = new MockFileSystem();
+            var path2 = XFS.Path(path);
+
+            fileSystem.AddDirectory(path2);
+
+            Assert.IsTrue(fileSystem.FileExists(path2));
+        }
+
+        [Test]
+        public void MockFileSystem_GetFiles_ThrowsArgumentExceptionForInvalidCharacters()
+        {
+            // Arrange
+            const string path = @"c:\";
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(path));
+            
+            // Act
+            TestDelegate getFilesWithInvalidCharacterInPath = () => fileSystem.Directory.GetFiles($"{path}{'\0'}.txt");
+
+            // Assert
+            Assert.Throws<ArgumentException>(getFilesWithInvalidCharacterInPath);
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase(@"C:\somepath")]
+        public void MockFileSystem_DefaultState_CurrentDirectoryExists(string currentDirectory)
+        {
+            var fs = new MockFileSystem(null, currentDirectory);
+
+            var actualCurrentDirectory = fs.DirectoryInfo.FromDirectoryName(".");
+
+            Assert.IsTrue(actualCurrentDirectory.Exists);
+        }
+    }
+}

--- a/tests/MockFileSystemWatcherFactoryTests.cs
+++ b/tests/MockFileSystemWatcherFactoryTests.cs
@@ -1,0 +1,52 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockFileSystemWatcherFactoryTests
+    {
+        [Test]
+        public void MockFileSystemWatcherFactory_CreateNew_ShouldReturnNonNullMockWatcher()
+        {
+            // Arrange
+            var factory = new MockFileSystemWatcherFactory();
+
+            // Act
+            var result = factory.CreateNew();
+
+            // Assert
+            Assert.IsNotNull(result);
+        }
+
+        [Test]
+        public void MockFileSystemWatcherFactory_FromPath_ShouldReturnNonNullMockWatcher()
+        {
+            // Arrange
+            var factory = new MockFileSystemWatcherFactory();
+
+            // Act
+            var result = factory.FromPath(@"y:\test");
+
+            // Assert
+            Assert.IsNotNull(result);
+        }
+
+        [Test]
+        public void MockFileSystemWatcherFactory_FromPath_ShouldReturnWatcherForSpecifiedPath()
+        {
+            // Arrange
+            const string path = @"z:\test";
+            var factory = new MockFileSystemWatcherFactory();
+
+            // Act
+            var result = factory.FromPath(path);
+
+            // Assert
+            Assert.AreEqual(path, result.Path);
+        }
+    }
+}

--- a/tests/MockFileTests.cs
+++ b/tests/MockFileTests.cs
@@ -1,0 +1,707 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+#if NET40
+using System.Runtime.Serialization.Formatters.Binary;
+#endif
+using System.Text;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    public class MockFileTests
+    {
+        [Test]
+        public void MockFile_Constructor_ShouldThrowArgumentNullExceptionIfMockFileDataAccessorIsNull()
+        {
+            // Arrange
+            // nothing to do
+
+            // Act
+            TestDelegate action = () => new MockFile(null);
+
+            // Assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Test]
+        public void MockFile_GetSetCreationTime_ShouldPersist()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("Demo text content") }
+            });
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var creationTime = new DateTime(2010, 6, 4, 13, 26, 42);
+            file.SetCreationTime(path, creationTime);
+            var result = file.GetCreationTime(path);
+
+            // Assert
+            Assert.AreEqual(creationTime, result);
+        }
+
+        [Test]
+        public void MockFile_SetCreationTimeUtc_ShouldAffectCreationTime()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("Demo text content") }
+            });
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var creationTime = new DateTime(2010, 6, 4, 13, 26, 42);
+            file.SetCreationTimeUtc(path, creationTime.ToUniversalTime());
+            var result = file.GetCreationTime(path);
+
+            // Assert
+            Assert.AreEqual(creationTime, result);
+        }
+
+        [Test]
+        public void MockFile_SetCreationTime_ShouldAffectCreationTimeUtc()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("Demo text content") }
+            });
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var creationTime = new DateTime(2010, 6, 4, 13, 26, 42);
+            file.SetCreationTime(path, creationTime);
+            var result = file.GetCreationTimeUtc(path);
+
+            // Assert
+            Assert.AreEqual(creationTime.ToUniversalTime(), result);
+        }
+
+        [Test]
+        public void MockFile_GetSetLastAccessTime_ShouldPersist()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("Demo text content") }
+            });
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var lastAccessTime = new DateTime(2010, 6, 4, 13, 26, 42);
+            file.SetLastAccessTime(path, lastAccessTime);
+            var result = file.GetLastAccessTime(path);
+
+            // Assert
+            Assert.AreEqual(lastAccessTime, result);
+        }
+
+        [Test]
+        public void MockFile_SetLastAccessTimeUtc_ShouldAffectLastAccessTime()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("Demo text content") }
+            });
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var lastAccessTime = new DateTime(2010, 6, 4, 13, 26, 42);
+            file.SetLastAccessTimeUtc(path, lastAccessTime.ToUniversalTime());
+            var result = file.GetLastAccessTime(path);
+
+            // Assert
+            Assert.AreEqual(lastAccessTime, result);
+        }
+
+        [Test]
+        public void MockFile_SetLastAccessTime_ShouldAffectLastAccessTimeUtc()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("Demo text content") }
+            });
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var lastAccessTime = new DateTime(2010, 6, 4, 13, 26, 42);
+            file.SetLastAccessTime(path, lastAccessTime);
+            var result = file.GetLastAccessTimeUtc(path);
+
+            // Assert
+            Assert.AreEqual(lastAccessTime.ToUniversalTime(), result);
+        }
+
+        [Test]
+        public void MockFile_GetSetLastWriteTime_ShouldPersist()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("Demo text content") }
+            });
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var lastWriteTime = new DateTime(2010, 6, 4, 13, 26, 42);
+            file.SetLastWriteTime(path, lastWriteTime);
+            var result = file.GetLastWriteTime(path);
+
+            // Assert
+            Assert.AreEqual(lastWriteTime, result);
+        }
+
+        static void ExecuteDefaultValueTest(Func<MockFile, string, DateTime> getDateValue)
+        {
+            var expected = new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc);
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+            var file = new MockFile(fileSystem);
+
+            var actual = getDateValue(file, path);
+
+            Assert.That(actual.ToUniversalTime(), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void MockFile_GetLastWriteTimeOfNonExistantFile_ShouldReturnDefaultValue()
+        {
+            ExecuteDefaultValueTest((f, p) => f.GetLastWriteTime(p));
+        }
+
+        [Test]
+        public void MockFile_GetLastWriteTimeUtcOfNonExistantFile_ShouldReturnDefaultValue() {
+            ExecuteDefaultValueTest((f, p) => f.GetLastWriteTimeUtc(p));
+        }
+
+        [Test]
+        public void MockFile_GetLastAccessTimeUtcOfNonExistantFile_ShouldReturnDefaultValue() {
+            ExecuteDefaultValueTest((f, p) => f.GetLastAccessTimeUtc(p));
+        }
+
+        [Test]
+        public void MockFile_GetLastAccessTimeOfNonExistantFile_ShouldReturnDefaultValue() {
+            ExecuteDefaultValueTest((f, p) => f.GetLastAccessTime(p));
+        }
+
+        [Test]
+        public void MockFile_GetAttributeOfNonExistantFileButParentDirectoryExists_ShouldThrowOneFileNotFoundException()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+
+            // Act
+            TestDelegate action = () => fileSystem.File.GetAttributes(XFS.Path(@"c:\something\demo.txt"));
+
+            // Assert
+            Assert.Throws<FileNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockFile_GetAttributeOfNonExistantFile_ShouldThrowOneDirectoryNotFoundException()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.GetAttributes(XFS.Path(@"c:\something\demo.txt"));
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockFile_GetAttributeOfExistingFile_ShouldReturnCorrectValue()
+        {
+            var filedata = new MockFileData("test")
+            {
+                Attributes = FileAttributes.Hidden
+            };
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"),  filedata }
+            });
+
+            var attributes = fileSystem.File.GetAttributes(XFS.Path(@"c:\something\demo.txt"));
+            Assert.That(attributes, Is.EqualTo(FileAttributes.Hidden));
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.UNCPaths)]
+        public void MockFile_GetAttributeOfExistingUncDirectory_ShouldReturnCorrectValue()
+        {
+            var filedata = new MockFileData("test");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"\\share\folder\demo.txt"), filedata }
+            });
+
+            var attributes = fileSystem.File.GetAttributes(XFS.Path(@"\\share\folder"));
+            Assert.That(attributes, Is.EqualTo(FileAttributes.Directory));
+        }
+
+        [Test]
+        public void MockFile_GetAttributeWithEmptyParameter_ShouldThrowOneArgumentException()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.GetAttributes(string.Empty);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.Message, Does.StartWith("The path is not of a legal form."));
+        }
+
+        [Test]
+        public void MockFile_GetAttributeWithIllegalParameter_ShouldThrowOneArgumentException()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.GetAttributes(string.Empty);
+
+            // Assert
+            // Note: The actual type of the exception differs from the documentation.
+            //       According to the documentation it should be of type NotSupportedException.
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
+        public void MockFile_GetCreationTimeOfNonExistantFile_ShouldReturnDefaultValue() {
+            ExecuteDefaultValueTest((f, p) => f.GetCreationTime(p));
+        }
+
+        [Test]
+        public void MockFile_GetCreationTimeUtcOfNonExistantFile_ShouldReturnDefaultValue() {
+            ExecuteDefaultValueTest((f, p) => f.GetCreationTimeUtc(p));
+        }
+
+        [Test]
+        public void MockFile_SetLastWriteTimeUtc_ShouldAffectLastWriteTime()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("Demo text content") }
+            });
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var lastWriteTime = new DateTime(2010, 6, 4, 13, 26, 42);
+            file.SetLastWriteTimeUtc(path, lastWriteTime.ToUniversalTime());
+            var result = file.GetLastWriteTime(path);
+
+            // Assert
+            Assert.AreEqual(lastWriteTime, result);
+        }
+
+        [Test]
+        public void MockFile_SetLastWriteTime_ShouldAffectLastWriteTimeUtc()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("Demo text content") }
+            });
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var lastWriteTime = new DateTime(2010, 6, 4, 13, 26, 42);
+            file.SetLastWriteTime(path, lastWriteTime);
+            var result = file.GetLastWriteTimeUtc(path);
+
+            // Assert
+            Assert.AreEqual(lastWriteTime.ToUniversalTime(), result);
+        }
+
+        [Test]
+        public void MockFile_ReadAllText_ShouldReturnOriginalTextData()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var result = file.ReadAllText(XFS.Path(@"c:\something\demo.txt"));
+
+            // Assert
+            Assert.AreEqual(
+                "Demo text content",
+                result);
+        }
+
+        [Test]
+        public void MockFile_ReadAllText_ShouldReturnOriginalDataWithCustomEncoding()
+        {
+            // Arrange
+            string text = "Hello there!";
+            var encodedText = Encoding.BigEndianUnicode.GetBytes(text);
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData(encodedText) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var result = file.ReadAllText(XFS.Path(@"c:\something\demo.txt"), Encoding.BigEndianUnicode);
+
+            // Assert
+            Assert.AreEqual(text, result);
+        }
+
+        public static IEnumerable<Encoding> GetEncodingsForReadAllText()
+        {
+            // little endian
+            yield return new UTF32Encoding(false, true, true);
+
+            // big endian
+            yield return new UTF32Encoding(true, true, true);
+            yield return new UTF8Encoding(true, true);
+
+            yield return new ASCIIEncoding();
+        }
+
+        [TestCaseSource(typeof(MockFileTests), "GetEncodingsForReadAllText")]
+        public void MockFile_ReadAllText_ShouldReturnTheOriginalContentWhenTheFileContainsDifferentEncodings(Encoding encoding)
+        {
+            // Arrange
+            string text = "Hello there!";
+            var encodedText = encoding.GetPreamble().Concat(encoding.GetBytes(text)).ToArray();
+            var path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+                {
+                    { path, new MockFileData(encodedText) }
+                });
+
+            // Act
+            var actualText = fileSystem.File.ReadAllText(path);
+
+            // Assert
+            Assert.AreEqual(text, actualText);
+        }
+
+        [Test]
+        public void MockFile_OpenWrite_ShouldCreateNewFiles() {
+            string filePath = XFS.Path(@"c:\something\demo.txt");
+            string fileContent = "this is some content";
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+
+            var bytes = new UTF8Encoding(true).GetBytes(fileContent);
+            var stream = fileSystem.File.OpenWrite(filePath);
+            stream.Write(bytes, 0, bytes.Length);
+            stream.Dispose();
+
+            Assert.That(fileSystem.FileExists(filePath), Is.True);
+            Assert.That(fileSystem.GetFile(filePath).TextContents, Is.EqualTo(fileContent));
+        }
+
+        [Test]
+        public void MockFile_OpenWrite_ShouldNotCreateFolders()
+        {
+            string filePath = XFS.Path(@"c:\something\demo.txt"); // c:\something does not exist: OpenWrite should fail
+            var fileSystem = new MockFileSystem();
+
+            Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.OpenWrite(filePath));
+        }
+
+        [Test]
+        public void MockFile_OpenWrite_ShouldOverwriteExistingFiles()
+        {
+            string filePath = XFS.Path(@"c:\something\demo.txt");
+            string startFileContent = "this is some content";
+            string endFileContent = "this is some other content";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {filePath, new MockFileData(startFileContent)}
+            });
+
+            var bytes = new UTF8Encoding(true).GetBytes(endFileContent);
+            var stream = fileSystem.File.OpenWrite(filePath);
+            stream.Write(bytes, 0, bytes.Length);
+            stream.Dispose();
+
+            Assert.That(fileSystem.FileExists(filePath), Is.True);
+            Assert.That(fileSystem.GetFile(filePath).TextContents, Is.EqualTo(endFileContent));
+        }
+
+        [Test]
+        public void MockFile_Delete_ShouldRemoveFileFromFileSystem()
+        {
+            string fullPath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { fullPath, new MockFileData("Demo text content") }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            file.Delete(fullPath);
+
+            Assert.That(fileSystem.FileExists(fullPath), Is.False);
+        }
+
+        [Test]
+        public void MockFile_Delete_Should_RemoveFiles()
+        {
+            string filePath = XFS.Path(@"c:\something\demo.txt");
+            string fileContent = "this is some content";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData> { { filePath, new MockFileData(fileContent) } });
+            Assert.AreEqual(1, fileSystem.AllFiles.Count());
+            fileSystem.File.Delete(filePath);
+            Assert.AreEqual(0, fileSystem.AllFiles.Count());
+        }
+
+        [Test]
+        public void MockFile_Delete_No_File_Does_Nothing()
+        {            
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { XFS.Path(@"c:\something\exist.txt"), new MockFileData("Demo text content") },
+            });
+
+            string filePath = XFS.Path(@"c:\something\not_exist.txt");
+
+            fileSystem.File.Delete(filePath);
+        }
+
+        [Test]
+        public void MockFile_AppendText_AppendTextToanExistingFile()
+        {
+            string filepath = XFS.Path(@"c:\something\does\exist.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { filepath, new MockFileData("I'm here. ") }
+            });
+
+            var stream = filesystem.File.AppendText(filepath);
+
+            stream.Write("Me too!");
+            stream.Flush();
+            stream.Dispose();
+
+            var file = filesystem.GetFile(filepath);
+            Assert.That(file.TextContents, Is.EqualTo("I'm here. Me too!"));
+        }
+
+        [Test]
+        public void MockFile_AppendText_CreatesNewFileForAppendToNonExistingFile()
+        {
+            string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            filesystem.AddDirectory(XFS.Path(@"c:\something\doesnt"));
+
+            var stream = filesystem.File.AppendText(filepath);
+
+            stream.Write("New too!");
+            stream.Flush();
+            stream.Dispose();
+
+            var file = filesystem.GetFile(filepath);
+            Assert.That(file.TextContents, Is.EqualTo("New too!"));
+            Assert.That(filesystem.FileExists(filepath));
+        }
+
+#if NET40
+        [Test]
+        public void Serializable_works()
+        {
+            //Arrange
+            MockFileData data = new MockFileData("Text Contents");
+
+            //Act
+            IFormatter formatter = new BinaryFormatter();
+            Stream stream = new MemoryStream();
+            formatter.Serialize(stream, data);
+
+            //Assert
+            Assert.Pass();
+        }
+
+        [Test]
+        public void Serializable_can_deserialize()
+        {
+            //Arrange
+            string textContentStr = "Text Contents";
+
+            //Act
+            MockFileData data = new MockFileData(textContentStr);
+
+            IFormatter formatter = new BinaryFormatter();
+            Stream stream = new MemoryStream();
+            formatter.Serialize(stream, data);
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            MockFileData deserialized = (MockFileData)formatter.Deserialize(stream);
+
+            //Assert
+            Assert.That(deserialized.TextContents, Is.EqualTo(textContentStr));
+        }
+#endif
+
+#if NET40
+        [Test]
+        public void MockFile_Encrypt_ShouldSetEncryptedAttribute()
+        {
+            // Arrange
+            var fileData = new MockFileData("Demo text content");
+            var filePath = XFS.Path(@"c:\a.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {filePath, fileData }
+            });
+
+            // Act
+            fileSystem.File.Encrypt(filePath);
+            var attributes = fileSystem.File.GetAttributes(filePath);
+
+            // Assert
+            Assert.AreEqual(FileAttributes.Encrypted, attributes & FileAttributes.Encrypted);
+        }
+
+        [Test]
+        public void MockFile_Decrypt_ShouldRemoveEncryptedAttribute()
+        {
+            // Arrange
+            const string Content = "Demo text content";
+            var fileData = new MockFileData(Content);
+            var filePath = XFS.Path(@"c:\a.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {filePath, fileData }
+            });
+            fileSystem.File.Encrypt(filePath);
+
+            // Act
+            fileSystem.File.Decrypt(filePath);
+            var attributes = fileSystem.File.GetAttributes(filePath);
+
+            // Assert
+            Assert.AreNotEqual(FileAttributes.Encrypted, attributes & FileAttributes.Encrypted);
+        }
+#endif
+
+#if NET40
+        [Test]
+        public void MockFile_Replace_ShouldReplaceFileContents()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path1 = XFS.Path(@"c:\temp\file1.txt");
+            var path2 = XFS.Path(@"c:\temp\file2.txt");
+            fileSystem.AddFile(path1, new MockFileData("1"));
+            fileSystem.AddFile(path2, new MockFileData("2"));
+
+            // Act
+            fileSystem.File.Replace(path1, path2, null);
+
+            Assert.AreEqual("1", fileSystem.File.ReadAllText(path2));
+        }
+
+        [Test]
+        public void MockFile_Replace_ShouldCreateBackup()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path1 = XFS.Path(@"c:\temp\file1.txt");
+            var path2 = XFS.Path(@"c:\temp\file2.txt");
+            var path3 = XFS.Path(@"c:\temp\file3.txt");
+            fileSystem.AddFile(path1, new MockFileData("1"));
+            fileSystem.AddFile(path2, new MockFileData("2"));
+
+            // Act
+            fileSystem.File.Replace(path1, path2, path3);
+
+            Assert.AreEqual("2", fileSystem.File.ReadAllText(path3));
+        }
+
+        [Test]
+        public void MockFile_Replace_ShouldThrowIfDirectoryOfBackupPathDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path1 = XFS.Path(@"c:\temp\file1.txt");
+            var path2 = XFS.Path(@"c:\temp\file2.txt");
+            var path3 = XFS.Path(@"c:\temp\subdirectory\file3.txt");
+            fileSystem.AddFile(path1, new MockFileData("1"));
+            fileSystem.AddFile(path2, new MockFileData("2"));
+
+            // Act
+            Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.Replace(path1, path2, path3));
+        }
+
+        [Test]
+        public void MockFile_Replace_ShouldThrowIfSourceFileDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path1 = XFS.Path(@"c:\temp\file1.txt");
+            var path2 = XFS.Path(@"c:\temp\file2.txt");
+            fileSystem.AddFile(path2, new MockFileData("2"));
+
+            Assert.Throws<FileNotFoundException>(() => fileSystem.File.Replace(path1, path2, null));
+        }
+
+        [Test]
+        public void MockFile_Replace_ShouldThrowIfDestinationFileDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path1 = XFS.Path(@"c:\temp\file1.txt");
+            var path2 = XFS.Path(@"c:\temp\file2.txt");
+            fileSystem.AddFile(path1, new MockFileData("1"));
+
+            Assert.Throws<FileNotFoundException>(() => fileSystem.File.Replace(path1, path2, null));
+        }
+
+        [Test]
+        public void MockFile_OpenRead_ShouldReturnReadOnlyStream()
+        {
+            // Tests issue #230
+            // Arrange
+            string filePath = XFS.Path(@"c:\something\demo.txt");
+            string startContent = "hi there";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { filePath, new MockFileData(startContent) }
+            });
+
+            // Act
+            var stream = fileSystem.File.OpenRead(filePath);
+
+            // Assert
+            Assert.IsFalse(stream.CanWrite);
+            Assert.Throws<NotSupportedException>(() => stream.WriteByte(0));
+        }
+#endif
+    }
+}

--- a/tests/MockFileWriteAllBytesTests.cs
+++ b/tests/MockFileWriteAllBytesTests.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    public class MockFileWriteAllBytesTests
+    {
+        [Test]
+        public void MockFile_WriteAllBytes_ShouldThrowDirectoryNotFoundExceptionIfPathDoesNotExists()
+        {
+            var fileSystem = new MockFileSystem();
+            string path = XFS.Path(@"c:\something\file.txt");
+            var fileContent = new byte[] { 1, 2, 3, 4 };
+
+            TestDelegate action = () => fileSystem.File.WriteAllBytes(path, fileContent);
+
+            Assert.Throws<DirectoryNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockFile_WriteAllBytes_ShouldWriteDataToMemoryFileSystem()
+        {
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+            var fileContent = new byte[] { 1, 2, 3, 4 };
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+
+            fileSystem.File.WriteAllBytes(path, fileContent);
+
+            Assert.AreEqual(fileContent, fileSystem.GetFile(path).Contents);
+        }
+
+        [Test]
+        public void MockFile_WriteAllBytes_ShouldThrowAnUnauthorizedAccessExceptionIfFileIsHidden()
+        {
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("this is hidden") },
+            });
+            fileSystem.File.SetAttributes(path, FileAttributes.Hidden);
+
+            TestDelegate action = () => fileSystem.File.WriteAllBytes(path, new byte[] { 123 });
+
+            Assert.Throws<UnauthorizedAccessException>(action, "Access to the path '{0}' is denied.", path);
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+        public void MockFile_WriteAllBytes_ShouldThrowAnArgumentExceptionIfContainsIllegalCharacters()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"C:"));
+
+            TestDelegate action = () => fileSystem.File.WriteAllBytes(XFS.Path(@"C:\a<b.txt"), new byte[] { 123 });
+
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
+        public void MockFile_WriteAllBytes_ShouldThrowAnArgumentNullExceptionIfPathIsNull()
+        {
+            var fileSystem = new MockFileSystem();
+
+            TestDelegate action = () => fileSystem.File.WriteAllBytes(null, new byte[] { 123 });
+
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Test]
+        public void MockFile_WriteAllBytes_ShouldThrowAnArgumentNullExceptionIfBytesAreNull()
+        {
+            var fileSystem = new MockFileSystem();
+            string path = XFS.Path(@"c:\something\demo.txt");
+
+            TestDelegate action = () => fileSystem.File.WriteAllBytes(path, null);
+
+            var exception = Assert.Throws<ArgumentNullException>(action);
+            Assert.That(exception.Message, Does.StartWith("Value cannot be null."));
+            Assert.That(exception.ParamName, Is.EqualTo("bytes"));
+        }
+    }
+}

--- a/tests/MockFileWriteAllLinesTests.cs
+++ b/tests/MockFileWriteAllLinesTests.cs
@@ -1,0 +1,303 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using NUnit.Framework;
+using XFS = System.IO.Abstractions.TestingHelpers.MockUnixSupport;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    public class MockFileWriteAllLinesTests
+    {
+        private class TestDataForWriteAllLines
+        {
+            public static readonly string Path = XFS.Path(@"c:\something\demo.txt");
+
+            public static IEnumerable ForDifferentEncoding
+            {
+                get
+                {
+                    var fileSystem = new MockFileSystem();
+                    fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+                    var fileContentEnumerable = new List<string> { "first line", "second line", "third line", "fourth and last line" };
+                    var fileContentArray = fileContentEnumerable.ToArray();
+                    Action writeEnumberable = () => fileSystem.File.WriteAllLines(Path, fileContentEnumerable);
+                    Action writeEnumberableUtf32 = () => fileSystem.File.WriteAllLines(Path, fileContentEnumerable, Encoding.UTF32);
+                    Action writeArray = () => fileSystem.File.WriteAllLines(Path, fileContentArray);
+                    Action writeArrayUtf32 = () => fileSystem.File.WriteAllLines(Path, fileContentArray, Encoding.UTF32);
+                    var expectedContent = string.Format(CultureInfo.InvariantCulture,
+                        "first line{0}second line{0}third line{0}fourth and last line{0}", Environment.NewLine);
+
+                    // IEnumerable
+                    yield return new TestCaseData(fileSystem, writeEnumberable, expectedContent)
+                        .SetName("WriteAllLines(string, IEnumerable<string>)");
+                    yield return new TestCaseData(fileSystem, writeEnumberableUtf32, expectedContent)
+                        .SetName("WriteAllLines(string, IEnumerable<string>, Encoding.UTF32)");
+
+                    // string[]
+                    yield return new TestCaseData(fileSystem, writeArray, expectedContent)
+                        .SetName("WriteAllLines(string, string[])");
+                    yield return new TestCaseData(fileSystem, writeArrayUtf32, expectedContent)
+                        .SetName("WriteAllLines(string, string[], Encoding.UTF32)");
+                }
+            }
+
+            public static IEnumerable ForIllegalPath
+            {
+                get
+                {
+                    const string illegalPath = "<<<";
+                    return GetCasesForArgumentChecking(illegalPath);
+                }
+            }
+
+            public static IEnumerable ForNullPath
+            {
+                get
+                {
+                    const string illegalPath = null;
+                    return GetCasesForArgumentChecking(illegalPath);
+                }
+            }
+
+            private static IEnumerable GetCasesForArgumentChecking(string path)
+            {
+                var fileSystem = new MockFileSystem();
+                var fileContentEnumerable = new List<string>();
+                var fileContentArray = fileContentEnumerable.ToArray();
+                TestDelegate writeEnumberable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
+                TestDelegate writeEnumberableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
+                TestDelegate writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
+                TestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
+
+                // IEnumerable
+                yield return new TestCaseData(writeEnumberable)
+                    .SetName("WriteAllLines(string, IEnumerable<string>) input: " + path);
+                yield return new TestCaseData(writeEnumberableUtf32)
+                    .SetName("WriteAllLines(string, IEnumerable<string>, Encoding.UTF32) input: " + path);
+
+                // string[]
+                yield return new TestCaseData(writeArray)
+                    .SetName("WriteAllLines(string, string[]) input: " + path);
+                yield return new TestCaseData(writeArrayUtf32)
+                    .SetName("WriteAllLines(string, string[], Encoding.UTF32) input: " + path);
+            }
+
+            private static IEnumerable ForNullEncoding
+            {
+                get
+                {
+                    var fileSystem = new MockFileSystem();
+                    var fileContentEnumerable = new List<string>();
+                    var fileContentArray = fileContentEnumerable.ToArray();
+                    TestDelegate writeEnumberableNull = () => fileSystem.File.WriteAllLines(Path, fileContentEnumerable, null);
+                    TestDelegate writeArrayNull = () => fileSystem.File.WriteAllLines(Path, fileContentArray, null);
+
+                    // IEnumerable
+                    yield return new TestCaseData(writeEnumberableNull)
+                        .SetName("WriteAllLines(string, IEnumerable<string>, Encoding.UTF32)");
+
+                    // string[]
+                    yield return new TestCaseData(writeArrayNull)
+                        .SetName("WriteAllLines(string, string[], Encoding.UTF32)");
+                }
+            }
+
+            public static IEnumerable ForPathIsDirectory
+            {
+                get
+                {
+                    var fileSystem = new MockFileSystem();
+                    var path = XFS.Path(@"c:\something");
+                    fileSystem.Directory.CreateDirectory(path);
+                    var fileContentEnumerable = new List<string>();
+                    var fileContentArray = fileContentEnumerable.ToArray();
+                    TestDelegate writeEnumberable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
+                    TestDelegate writeEnumberableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
+                    TestDelegate writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
+                    TestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
+
+                    // IEnumerable
+                    yield return new TestCaseData(writeEnumberable, path)
+                        .SetName("WriteAllLines(string, IEnumerable<string>)");
+                    yield return new TestCaseData(writeEnumberableUtf32, path)
+                        .SetName("WriteAllLines(string, IEnumerable<string>, Encoding.UTF32)");
+
+                    // string[]
+                    yield return new TestCaseData(writeArray, path)
+                        .SetName("WriteAllLines(string, string[])");
+                    yield return new TestCaseData(writeArrayUtf32, path)
+                        .SetName("WriteAllLines(string, string[], Encoding.UTF32)");
+                }
+            }
+
+            public static IEnumerable ForFileIsReadOnly
+            {
+                get
+                {
+                    var fileSystem = new MockFileSystem();
+                    var path = XFS.Path(@"c:\something\file.txt");
+                    var mockFileData = new MockFileData(string.Empty);
+                    mockFileData.Attributes = FileAttributes.ReadOnly;
+                    fileSystem.AddFile(path, mockFileData);
+                    var fileContentEnumerable = new List<string>();
+                    var fileContentArray = fileContentEnumerable.ToArray();
+                    TestDelegate writeEnumberable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
+                    TestDelegate writeEnumberableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
+                    TestDelegate writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
+                    TestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
+
+                    // IEnumerable
+                    yield return new TestCaseData(writeEnumberable, path)
+                        .SetName("WriteAllLines(string, IEnumerable<string>)");
+                    yield return new TestCaseData(writeEnumberableUtf32, path)
+                        .SetName("WriteAllLines(string, IEnumerable<string>, Encoding.UTF32)");
+
+                    // string[]
+                    yield return new TestCaseData(writeArray, path)
+                        .SetName("WriteAllLines(string, string[])");
+                    yield return new TestCaseData(writeArrayUtf32, path)
+                        .SetName("WriteAllLines(string, string[], Encoding.UTF32)");
+                }
+            }
+
+            public static IEnumerable ForContentsIsNull
+            {
+                get
+                {
+                    var fileSystem = new MockFileSystem();
+                    var path = XFS.Path(@"c:\something\file.txt");
+                    var mockFileData = new MockFileData(string.Empty);
+                    mockFileData.Attributes = FileAttributes.ReadOnly;
+                    fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+                    fileSystem.AddFile(path, mockFileData);
+                    List<string> fileContentEnumerable = null;
+                    string[] fileContentArray = null;
+
+                    // ReSharper disable ExpressionIsAlwaysNull
+                    TestDelegate writeEnumberable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
+                    TestDelegate writeEnumberableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
+                    TestDelegate writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
+                    TestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
+                    // ReSharper restore ExpressionIsAlwaysNull
+
+                    // IEnumerable
+                    yield return new TestCaseData(writeEnumberable)
+                        .SetName("WriteAllLines(string, IEnumerable<string>)");
+                    yield return new TestCaseData(writeEnumberableUtf32)
+                        .SetName("WriteAllLines(string, IEnumerable<string>, Encoding.UTF32)");
+
+                    // string[]
+                    yield return new TestCaseData(writeArray)
+                        .SetName("WriteAllLines(string, string[])");
+                    yield return new TestCaseData(writeArrayUtf32)
+                        .SetName("WriteAllLines(string, string[], Encoding.UTF32)");
+                }
+            }
+        }
+
+        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForDifferentEncoding")]
+        public void MockFile_WriteAllLinesGeneric_ShouldWriteTheCorrectContent(IMockFileDataAccessor fileSystem, Action action, string expectedContent)
+        {
+            // Arrange
+            // is done in the test case source
+
+            // Act
+            action();
+
+            // Assert
+            var actualContent = fileSystem.GetFile(TestDataForWriteAllLines.Path).TextContents;
+            Assert.That(actualContent, Is.EqualTo(expectedContent));
+        }
+
+        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForNullPath")]
+        public void MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentNullExceptionIfPathIsNull(TestDelegate action)
+        {
+            // Arrange
+            // is done in the test case source
+
+            // Act
+            // is done in the test case source
+
+            // Assert
+            var exception = Assert.Throws<ArgumentNullException>(action);
+            Assert.That(exception.Message, Does.StartWith("Value cannot be null."));
+            Assert.That(exception.ParamName, Does.StartWith("path"));
+        }
+
+        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForNullEncoding")]
+        public void MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentNullExceptionIfEncodingIsNull(TestDelegate action)
+        {
+            // Arrange
+            // is done in the test case source
+
+            // Act
+            // is done in the test case source
+
+            // Assert
+            var exception = Assert.Throws<ArgumentNullException>(action);
+            Assert.That(exception.Message, Does.StartWith("Value cannot be null."));
+            Assert.That(exception.ParamName, Does.StartWith("encoding"));
+        }
+
+        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForIllegalPath")]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+        public void MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentExceptionIfPathContainsIllegalCharacters(TestDelegate action)
+        {            
+            // Arrange
+            // is done in the test case source
+
+            // Act
+            // is done in the test case source
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."));
+        }
+
+        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForPathIsDirectory")]
+        public void MockFile_WriteAllLinesGeneric_ShouldThrowAnUnauthorizedAccessExceptionIfPathIsOneDirectory(TestDelegate action, string path)
+        {
+            // Arrange
+            // is done in the test case source
+
+            // Act
+            // is done in the test case source
+
+            // Assert
+            var exception = Assert.Throws<UnauthorizedAccessException>(action);
+            var expectedMessage = string.Format(CultureInfo.InvariantCulture, "Access to the path '{0}' is denied.", path);
+            Assert.That(exception.Message, Is.EqualTo(expectedMessage));
+        }
+
+        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForFileIsReadOnly")]
+        public void MockFile_WriteAllLinesGeneric_ShouldThrowOneUnauthorizedAccessExceptionIfFileIsReadOnly(TestDelegate action, string path)
+        {
+            // Arrange
+            // is done in the test case source
+
+            // Act
+            // is done in the test case source
+
+            // Assert
+            var exception = Assert.Throws<UnauthorizedAccessException>(action);
+            var expectedMessage = string.Format(CultureInfo.InvariantCulture, "Access to the path '{0}' is denied.", path);
+            Assert.That(exception.Message, Is.EqualTo(expectedMessage));
+        }
+
+        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForContentsIsNull")]
+        public void MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentNullExceptionIfContentsIsNull(TestDelegate action)
+        {
+            // Arrange
+            // is done in the test case source
+
+            // Act
+            // is done in the test case sourceForContentsIsNull
+
+            // Assert
+            var exception = Assert.Throws<ArgumentNullException>(action);
+            Assert.That(exception.Message, Does.StartWith("Value cannot be null."));
+            Assert.That(exception.ParamName, Is.EqualTo("contents"));
+        }
+    }
+}

--- a/tests/MockFileWriteAllTextTests.cs
+++ b/tests/MockFileWriteAllTextTests.cs
@@ -1,0 +1,227 @@
+﻿namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using Collections.Generic;
+
+    using NUnit.Framework;
+
+    using Text;
+
+    using XFS = MockUnixSupport;
+
+    public class MockFileWriteAllTextTests {
+        [Test]
+        public void MockFile_WriteAllText_ShouldWriteTextFileToMemoryFileSystem()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            string fileContent = "Hello there!";
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+
+            // Act
+            fileSystem.File.WriteAllText(path, fileContent);
+
+            // Assert
+            Assert.AreEqual(
+                fileContent,
+                fileSystem.GetFile(path).TextContents);
+        }
+
+        [Test]
+        public void MockFile_WriteAllText_ShouldOverriteAnExistingFile()
+        {
+            // http://msdn.microsoft.com/en-us/library/ms143375.aspx
+
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+
+            // Act
+            fileSystem.File.WriteAllText(path, "foo");
+            fileSystem.File.WriteAllText(path, "bar");
+
+            // Assert
+            Assert.AreEqual("bar", fileSystem.GetFile(path).TextContents);
+        }
+
+        [Test]
+        public void MockFile_WriteAllText_ShouldThrowAnUnauthorizedAccessExceptionIfFileIsHidden()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { path, new MockFileData("this is hidden") },
+            });
+            fileSystem.File.SetAttributes(path, FileAttributes.Hidden);
+
+            // Act
+            TestDelegate action = () => fileSystem.File.WriteAllText(path, "hello world");
+
+            // Assert
+            Assert.Throws<UnauthorizedAccessException>(action, "Access to the path '{0}' is denied.", path);
+        }
+
+        [Test]
+        public void MockFile_WriteAllText_ShouldThrowAnArgumentExceptionIfThePathIsEmpty()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.File.WriteAllText(string.Empty, "hello world");
+
+            // Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
+        public void MockFile_WriteAllText_ShouldNotThrowAnArgumentNullExceptionIfTheContentIsNull()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string directoryPath = XFS.Path(@"c:\something");
+            string filePath = XFS.Path(@"c:\something\demo.txt");
+            fileSystem.AddDirectory(directoryPath);
+
+            // Act
+            fileSystem.File.WriteAllText(filePath, null);
+
+            // Assert
+            // no exception should be thrown, also the documentation says so
+            var data = fileSystem.GetFile(filePath);
+            Assert.That(data.Contents, Is.Empty);
+        }
+
+        [Test]
+        public void MockFile_WriteAllText_ShouldThrowAnUnauthorizedAccessExceptionIfTheFileIsReadOnly()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string filePath = XFS.Path(@"c:\something\demo.txt");
+            var mockFileData = new MockFileData(new byte[0]);
+            mockFileData.Attributes = FileAttributes.ReadOnly;
+            fileSystem.AddFile(filePath, mockFileData);
+
+            // Act
+            TestDelegate action = () => fileSystem.File.WriteAllText(filePath, null);
+
+            // Assert
+            Assert.Throws<UnauthorizedAccessException>(action);
+        }
+
+        [Test]
+        public void MockFile_WriteAllText_ShouldThrowAnUnauthorizedAccessExceptionIfThePathIsOneDirectory()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string directoryPath = XFS.Path(@"c:\something");
+            fileSystem.AddDirectory(directoryPath);
+
+            // Act
+            TestDelegate action = () => fileSystem.File.WriteAllText(directoryPath, null);
+
+            // Assert
+            Assert.Throws<UnauthorizedAccessException>(action);
+        }
+
+        [Test]
+        public void MockFile_WriteAllText_ShouldThrowDirectoryNotFoundExceptionIfPathDoesNotExists()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string path = XFS.Path(@"c:\something\file.txt");
+
+            // Act
+            TestDelegate action = () => fileSystem.File.WriteAllText(path, string.Empty);
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(action);
+        }
+
+        public static IEnumerable<KeyValuePair<Encoding, byte[]>> GetEncodingsWithExpectedBytes()
+        {
+            Encoding utf8WithoutBom = new UTF8Encoding(false, true);
+            return new Dictionary<Encoding, byte[]>
+            {
+                // ASCII does not need a BOM
+                { Encoding.ASCII, new byte[] { 72, 101, 108, 108, 111, 32, 116,
+                    104, 101, 114, 101, 33, 32, 68, 122, 105, 63, 107, 105, 46 } },
+
+                // BigEndianUnicode needs a BOM, the BOM is the first two bytes
+                { Encoding.BigEndianUnicode, new byte [] { 254, 255, 0, 72, 0, 101,
+                    0, 108, 0, 108, 0, 111, 0, 32, 0, 116, 0, 104, 0, 101, 0, 114,
+                    0, 101, 0, 33, 0, 32, 0, 68, 0, 122, 0, 105, 1, 25, 0, 107, 0, 105, 0, 46 } },
+
+#if NET40
+                // Default encoding does not need a BOM
+                { Encoding.Default, new byte [] { 72, 101, 108, 108, 111, 32, 116,
+                    104, 101, 114, 101, 33, 32, 68, 122, 105, 101, 107, 105, 46 } },
+#endif
+                // UTF-32 needs a BOM, the BOM is the first four bytes
+                { Encoding.UTF32, new byte [] {255, 254, 0, 0, 72, 0, 0, 0, 101,
+                    0, 0, 0, 108, 0, 0, 0, 108, 0, 0, 0, 111, 0, 0, 0, 32, 0, 0,
+                    0, 116, 0, 0, 0, 104, 0, 0, 0, 101, 0, 0, 0, 114, 0, 0, 0,
+                    101, 0, 0, 0, 33, 0, 0, 0, 32, 0, 0, 0, 68, 0, 0, 0, 122, 0,
+                    0, 0, 105, 0, 0, 0, 25, 1, 0, 0, 107, 0, 0, 0, 105, 0, 0, 0, 46, 0, 0, 0 } },
+
+                // UTF-7 does not need a BOM
+                { Encoding.UTF7, new byte [] {72, 101, 108, 108, 111, 32, 116,
+                    104, 101, 114, 101, 43, 65, 67, 69, 45, 32, 68, 122, 105,
+                    43, 65, 82, 107, 45, 107, 105, 46 } },
+
+                // The default encoding does not need a BOM
+                { utf8WithoutBom, new byte [] { 72, 101, 108, 108, 111, 32, 116,
+                    104, 101, 114, 101, 33, 32, 68, 122, 105, 196, 153, 107, 105, 46 } },
+
+                // Unicode needs a BOM, the BOM is the first two bytes
+                { Encoding.Unicode, new byte [] { 255, 254, 72, 0, 101, 0, 108,
+                    0, 108, 0, 111, 0, 32, 0, 116, 0, 104, 0, 101, 0, 114, 0,
+                    101, 0, 33, 0, 32, 0, 68, 0, 122, 0, 105, 0, 25, 1, 107, 0,
+                    105, 0, 46, 0 } }
+            };
+        }
+
+        [TestCaseSource(typeof(MockFileWriteAllTextTests), "GetEncodingsWithExpectedBytes")]
+        public void MockFile_WriteAllText_Encoding_ShouldWriteTextFileToMemoryFileSystem(KeyValuePair<Encoding, byte[]> encodingsWithContents)
+        {
+            // Arrange
+            const string FileContent = "Hello there! Dzięki.";
+            string path = XFS.Path(@"c:\something\demo.txt");
+            byte[] expectedBytes = encodingsWithContents.Value;
+            Encoding encoding = encodingsWithContents.Key;
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+
+            // Act
+            fileSystem.File.WriteAllText(path, FileContent, encoding);
+
+            // Assert
+            var actualBytes = fileSystem.GetFile(path).Contents;
+            Assert.AreEqual(expectedBytes, actualBytes);
+        }
+
+        [Test]
+        public void MockFile_WriteAllTextMultipleLines_ShouldWriteTextFileToMemoryFileSystem()
+        {
+            // Arrange
+            string path = XFS.Path(@"c:\something\demo.txt");
+
+            var fileContent = new List<string> {"Hello there!", "Second line!"};
+            var expected = "Hello there!" + Environment.NewLine + "Second line!" + Environment.NewLine;
+
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+
+            // Act
+            fileSystem.File.WriteAllLines(path, fileContent);
+
+            // Assert
+            Assert.AreEqual(
+                expected,
+                fileSystem.GetFile(path).TextContents);
+        }
+
+    }
+}

--- a/tests/MockPathTests.cs
+++ b/tests/MockPathTests.cs
@@ -1,0 +1,401 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    public class MockPathTests
+    {
+        static readonly string TestPath = XFS.Path("C:\\test\\test.bmp");
+
+        [Test]
+        public void ChangeExtension_ExtensionNoPeriod_PeriodAdded()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.ChangeExtension(TestPath, "doc");
+
+            //Assert
+            Assert.AreEqual(XFS.Path("C:\\test\\test.doc"), result);
+        }
+
+        [Test]
+        public void Combine_SentTwoPaths_Combines()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.Combine(XFS.Path("C:\\test"), "test.bmp");
+
+            //Assert
+            Assert.AreEqual(XFS.Path("C:\\test\\test.bmp"), result);
+        }
+
+        [Test]
+        public void Combine_SentThreePaths_Combines()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.Combine(XFS.Path("C:\\test"), "subdir1", "test.bmp");
+
+            //Assert
+            Assert.AreEqual(XFS.Path("C:\\test\\subdir1\\test.bmp"), result);
+        }
+
+        [Test]
+        public void Combine_SentFourPaths_Combines()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.Combine(XFS.Path("C:\\test"), "subdir1", "subdir2", "test.bmp");
+
+            //Assert
+            Assert.AreEqual(XFS.Path("C:\\test\\subdir1\\subdir2\\test.bmp"), result);
+        }
+
+        [Test]
+        public void Combine_SentFivePaths_Combines()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.Combine(XFS.Path("C:\\test"), "subdir1", "subdir2", "subdir3", "test.bmp");
+
+            //Assert
+            Assert.AreEqual(XFS.Path("C:\\test\\subdir1\\subdir2\\subdir3\\test.bmp"), result);
+        }
+
+        [Test]
+        public void GetDirectoryName_SentPath_ReturnsDirectory()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.GetDirectoryName(TestPath);
+
+            //Assert
+            Assert.AreEqual(XFS.Path("C:\\test"), result);
+        }
+
+        [Test]
+        public void GetExtension_SendInPath_ReturnsExtension()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.GetExtension(TestPath);
+
+            //Assert
+            Assert.AreEqual(".bmp", result);
+        }
+
+        [Test]
+        public void GetFileName_SendInPath_ReturnsFilename()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.GetFileName(TestPath);
+
+            //Assert
+            Assert.AreEqual("test.bmp", result);
+        }
+
+        [Test]
+        public void GetFileNameWithoutExtension_SendInPath_ReturnsFileNameNoExt()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.GetFileNameWithoutExtension(TestPath);
+
+            //Assert
+            Assert.AreEqual("test", result);
+        }
+
+        [Test]
+        public void GetFullPath_SendInPath_ReturnsFullPath()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.GetFullPath(TestPath);
+
+            //Assert
+            Assert.AreEqual(TestPath, result);
+        }
+
+        public static IEnumerable<string[]> GetFullPath_RelativePaths_Cases
+        {
+            get
+            {
+                yield return new [] { XFS.Path(@"c:\a"), "b", XFS.Path(@"c:\a\b") };
+                yield return new [] { XFS.Path(@"c:\a\b"), "c", XFS.Path(@"c:\a\b\c") };
+                yield return new [] { XFS.Path(@"c:\a\b"), XFS.Path(@"c\"), XFS.Path(@"c:\a\b\c\") };
+                yield return new [] { XFS.Path(@"c:\a\b"), XFS.Path(@"..\c"), XFS.Path(@"c:\a\c") };
+                yield return new [] { XFS.Path(@"c:\a\b\c"), XFS.Path(@"..\c\..\"), XFS.Path(@"c:\a\b\") };
+                yield return new [] { XFS.Path(@"c:\a\b\c"), XFS.Path(@"..\..\..\..\..\d"), XFS.Path(@"c:\d") };
+                yield return new [] { XFS.Path(@"c:\a\b\c"), XFS.Path(@"..\..\..\..\..\d\"), XFS.Path(@"c:\d\") };
+            }
+        }
+
+        [TestCaseSource("GetFullPath_RelativePaths_Cases")]
+        public void GetFullPath_RelativePaths_ShouldReturnTheAbsolutePathWithCurrentDirectory(string currentDir, string relativePath, string expectedResult)
+        {
+            //Arrange
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.Directory.SetCurrentDirectory(currentDir);
+            var mockPath = new MockPath(mockFileSystem);
+
+            //Act
+            var actualResult = mockPath.GetFullPath(relativePath);
+
+            //Assert
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        public static IEnumerable<string[]> GetFullPath_RootedPathWithRelativeSegments_Cases
+        {
+            get
+            {
+                yield return new [] { XFS.Path(@"c:\a\b\..\c"), XFS.Path(@"c:\a\c") };
+                yield return new [] { XFS.Path(@"c:\a\b\.\.\..\.\c"), XFS.Path(@"c:\a\c") };
+                yield return new [] { XFS.Path(@"c:\a\b\.\c"), XFS.Path(@"c:\a\b\c") };
+                yield return new [] { XFS.Path(@"c:\a\b\.\.\.\.\c"), XFS.Path(@"c:\a\b\c") };
+                yield return new [] { XFS.Path(@"c:\a\..\..\c"), XFS.Path(@"c:\c") };
+            }
+        }
+
+        [TestCaseSource("GetFullPath_RootedPathWithRelativeSegments_Cases")]
+        public void GetFullPath_RootedPathWithRelativeSegments_ShouldReturnAnRootedAbsolutePath(string rootedPath, string expectedResult)
+        {
+            //Arrange
+            var mockFileSystem = new MockFileSystem();
+            var mockPath = new MockPath(mockFileSystem);
+
+            //Act
+            var actualResult = mockPath.GetFullPath(rootedPath);
+
+            //Assert
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        public static IEnumerable<string[]> GetFullPath_AbsolutePaths_Cases
+        {
+            get
+            {
+                yield return new [] { XFS.Path(@"c:\a"), XFS.Path(@"/b"), XFS.Path(@"c:\b") };
+                yield return new [] { XFS.Path(@"c:\a"), XFS.Path(@"/b\"), XFS.Path(@"c:\b\") };
+                yield return new [] { XFS.Path(@"c:\a"), XFS.Path(@"\b"), XFS.Path(@"c:\b") };
+                yield return new [] { XFS.Path(@"c:\a"), XFS.Path(@"\b\..\c"), XFS.Path(@"c:\c") };
+                yield return new [] { XFS.Path(@"z:\a"), XFS.Path(@"\b\..\c"), XFS.Path(@"z:\c") };
+                yield return new [] { XFS.Path(@"z:\a"), XFS.Path(@"\\computer\share\c"), XFS.Path(@"\\computer\share\c") };
+                yield return new [] { XFS.Path(@"z:\a"), XFS.Path(@"\\computer\share\c\..\d"), XFS.Path(@"\\computer\share\d") };
+                yield return new [] { XFS.Path(@"z:\a"), XFS.Path(@"\\computer\share\c\..\..\d"), XFS.Path(@"\\computer\share\d") };
+            }
+        }
+
+        [TestCaseSource("GetFullPath_AbsolutePaths_Cases")]
+        public void GetFullPath_AbsolutePaths_ShouldReturnThePathWithTheRoot_Or_Unc(string currentDir, string absolutePath, string expectedResult)
+        {
+            //Arrange
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.Directory.SetCurrentDirectory(currentDir);
+            var mockPath = new MockPath(mockFileSystem);
+
+            //Act
+            var actualResult = mockPath.GetFullPath(absolutePath);
+
+            //Assert
+            Assert.AreEqual(expectedResult, actualResult);
+        }
+
+        [Test]
+        public void GetFullPath_InvalidUNCPaths_ShouldThrowArgumentException()
+        {
+            //Arrange
+            var mockFileSystem = new MockFileSystem();
+            var mockPath = new MockPath(mockFileSystem);
+
+            //Act
+            TestDelegate action = () => mockPath.GetFullPath(XFS.Path(@"\\shareZ"));
+
+            //Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
+        public void GetFullPath_NullValue_ShouldThrowArgumentNullException()
+        {
+            //Arrange
+            var mockFileSystem = new MockFileSystem();
+            var mockPath = new MockPath(mockFileSystem);
+
+            //Act
+            TestDelegate action = () => mockPath.GetFullPath(null);
+
+            //Assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Test]
+        public void GetFullPath_EmptyValue_ShouldThrowArgumentException()
+        {
+            //Arrange
+            var mockFileSystem = new MockFileSystem();
+            var mockPath = new MockPath(mockFileSystem);
+
+            //Act
+            TestDelegate action = () => mockPath.GetFullPath(string.Empty);
+
+            //Assert
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
+        public void GetFullPath_WithMultipleDirectorySeparators_ShouldReturnTheNormalizedForm()
+        {
+            //Arrange
+            var mockFileSystem = new MockFileSystem();
+            var mockPath = new MockPath(mockFileSystem);
+
+            //Act
+            var actualFullPath =  mockPath.GetFullPath(XFS.Path(@"c:\foo\\//bar\file.dat"));
+
+            //Assert
+            Assert.AreEqual(XFS.Path(@"c:\foo\bar\file.dat"), actualFullPath);
+        }
+
+        [Test]
+        public void GetInvalidFileNameChars_Called_ReturnsChars()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.GetInvalidFileNameChars();
+
+            //Assert
+            Assert.IsTrue(result.Length > 0);
+        }
+
+        [Test]
+        public void GetInvalidPathChars_Called_ReturnsChars()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.GetInvalidPathChars();
+
+            //Assert
+            Assert.IsTrue(result.Length > 0);
+        }
+
+        [Test]
+        public void GetPathRoot_SendInPath_ReturnsRoot()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.GetPathRoot(TestPath);
+
+            //Assert
+            Assert.AreEqual(XFS.Path("C:\\"), result);
+        }
+
+        [Test]
+        public void GetRandomFileName_Called_ReturnsStringLengthGreaterThanZero()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.GetRandomFileName();
+
+            //Assert
+            Assert.IsTrue(result.Length > 0);
+        }
+
+        [Test]
+        public void GetTempFileName_Called_ReturnsStringLengthGreaterThanZero()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.GetTempFileName();
+
+            //Assert
+            Assert.IsTrue(result.Length > 0);
+        }
+
+        [Test]
+        public void GetTempFileName_Called_CreatesEmptyFileInTempDirectory()
+        {
+            //Arrange
+            var fileSystem = new MockFileSystem();
+            var mockPath = new MockPath(fileSystem);
+
+            //Act
+            var result = mockPath.GetTempFileName();
+
+            Assert.True(fileSystem.FileExists(result));
+            Assert.AreEqual(0, fileSystem.FileInfo.FromFileName(result).Length);
+        }
+
+        [Test]
+        public void GetTempPath_Called_ReturnsStringLengthGreaterThanZero()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.GetTempPath();
+
+            //Assert
+            Assert.IsTrue(result.Length > 0);
+        }
+
+        [Test]
+        public void HasExtension_PathSentIn_DeterminesExtension()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.HasExtension(TestPath);
+
+            //Assert
+            Assert.AreEqual(true, result);
+        }
+
+        [Test]
+        public void IsPathRooted_PathSentIn_DeterminesPathExists()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.IsPathRooted(TestPath);
+
+            //Assert
+            Assert.AreEqual(true, result);
+        }
+    }
+}

--- a/tests/MockUnixSupportTests.cs
+++ b/tests/MockUnixSupportTests.cs
@@ -1,0 +1,20 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockUnixSupportTests
+    {
+        [Test]
+        public void Should_Convert_Backslashes_To_Slashes_On_Unix()
+        {
+            Assert.AreEqual("/test/", MockUnixSupport.Path(@"\test\", () => true));
+        }
+
+        [Test]
+        public void Should_Remove_Drive_Letter_On_Unix()
+        {
+            Assert.AreEqual("/test/", MockUnixSupport.Path(@"c:\test\", () => true));
+        }
+    }
+}

--- a/tests/Shared.cs
+++ b/tests/Shared.cs
@@ -1,0 +1,21 @@
+﻿namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    internal static class Shared
+    {
+        /// <summary>
+        /// These chars are not valid path chars but do not cause the same
+        /// errors that other <code>Path.GetInvalidFileNameChars()</code> will.
+        /// </summary>
+        public static char[] SpecialInvalidPathChars(IFileSystem fileSystem) => new[]
+        {
+            // These are not allowed in a file name, but
+            // inserting them a path does not make it invalid
+            fileSystem.Path.DirectorySeparatorChar,
+            fileSystem.Path.AltDirectorySeparatorChar,
+
+            // Raises a different type of exception from other
+            // invalid chars and is covered by other tests
+            fileSystem.Path.VolumeSeparatorChar
+        };
+    }
+}

--- a/tests/StringExtensionsTests.cs
+++ b/tests/StringExtensionsTests.cs
@@ -1,0 +1,116 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    public class StringExtensionsTests
+    {
+        [Test]
+        public void SplitLines_InputWithOneLine_ShouldReturnOnlyOneLine()
+        {
+            var input = "This is row one";
+            var expected = new[] { "This is row one" };
+
+            var result = input.SplitLines();
+
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void SplitLines_InputWithTwoLinesSeparatedWithLf_ShouldReturnBothLines() {
+            var input = "This is row one\nThis is row two";
+            var expected = new[] { "This is row one", "This is row two" };
+
+            var result = input.SplitLines();
+
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void SplitLines_InputWithTwoLinesSeparatedWithCr_ShouldReturnBothLines() {
+            var input = "This is row one\rThis is row two";
+            var expected = new[] { "This is row one", "This is row two" };
+
+            var result = input.SplitLines();
+
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void SplitLines_InputWithTwoLinesSeparatedWithCrLf_ShouldReturnBothLines() {
+            var input = "This is row one\r\nThis is row two";
+            var expected = new[] { "This is row one", "This is row two" };
+
+            var result = input.SplitLines();
+
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        public void SplitLines_InputWithTwoLinesSeparatedWithAllLineEndings_ShouldReturnAllLines() {
+            var input = "one\r\ntwo\rthree\nfour";
+            var expected = new[] { "one", "two", "three", "four" };
+
+            var result = input.SplitLines();
+
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void TrimSlashes_DriveRoot_PreserveTrailingSlash()
+        {
+            Assert.AreEqual(@"c:\", @"c:\".TrimSlashes());
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void TrimSlashes_DriveRoot_AppendsTrailingSlash()
+        {
+            Assert.AreEqual(@"c:\", @"c:".TrimSlashes());
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void TrimSlashes_DriveRoot_TrimsExcessTrailingSlash()
+        {
+            Assert.AreEqual(@"c:\", @"c:\\".TrimSlashes());
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void TrimSlashes_DriveRoot_NormalizeAlternateSlash()
+        {
+            Assert.AreEqual(@"c:\", @"c:/".TrimSlashes());
+        }
+
+        [Test]
+        [WindowsOnly(WindowsSpecifics.Drives)]
+        public void TrimSlashes_RootedPath_TrimsAllTrailingSlashes()
+        {
+            Assert.AreEqual(@"c:\x", @"c:\x\".TrimSlashes());
+        }
+
+        [Test]
+        public void TrimSlashes_RootedPath_DontAlterPathWithoutTrailingSlashes()
+        {
+            Assert.AreEqual(XFS.Path(@"c:\x"), XFS.Path(@"c:\x").TrimSlashes());
+        }
+
+        [Test]
+        [UnixOnly(UnixSpecifics.SlashRoot)]
+        public void TrimSlashes_SlashRoot_TrimsExcessTrailingSlash()
+        {
+            Assert.AreEqual("/", "//".TrimSlashes());
+        }
+
+        [Test]
+        [UnixOnly(UnixSpecifics.SlashRoot)]
+        public void TrimSlashes_SlashRoot_PreserveSlashRoot()
+        {
+            Assert.AreEqual("/", "/".TrimSlashes());
+        }
+    }
+}

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests.csproj
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests.csproj
@@ -1,0 +1,55 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net40;netcoreapp2.0</TargetFrameworks>
+    <Version>0.0.0.1</Version>
+    <Description>The unit tests for our pre-built mocks</Description>
+    <Company />
+    <Product>System.IO.Abstractions</Product>
+    <Copyright>Copyright © Tatham Oddie 2010</Copyright>
+    <Authors>Tatham Oddie</Authors>
+    <RootNamespace>System.IO.Abstractions.TestingHelpers.Tests</RootNamespace>
+    <AssemblyOriginatorKeyFile>../StrongName.snk</AssemblyOriginatorKeyFile>
+    <IsPackable>false</IsPackable>
+
+    <!-- Workaround for https://github.com/nunit/nunit3-vs-adapter/issues/296 -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <SignAssembly>False</SignAssembly>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+      <SignAssembly>True</SignAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="TestFiles\SecondTestFile.txt" />
+    <None Remove="TestFiles\TestFile.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="TestFiles\SecondTestFile.txt" />
+    <EmbeddedResource Include="TestFiles\TestFile.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../System.IO.Abstractions/System.IO.Abstractions.csproj" />
+    <ProjectReference Include="../System.IO.Abstractions.TestingHelpers/System.IO.Abstractions.TestingHelpers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net40'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.8.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>

--- a/tests/TestFiles/SecondTestFile.txt
+++ b/tests/TestFiles/SecondTestFile.txt
@@ -1,0 +1,1 @@
+This is a the second test file.

--- a/tests/TestFiles/TestFile.txt
+++ b/tests/TestFiles/TestFile.txt
@@ -1,0 +1,1 @@
+This is a test file.

--- a/tests/UnixOnlyAttribute.cs
+++ b/tests/UnixOnlyAttribute.cs
@@ -1,0 +1,27 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    internal sealed class UnixOnlyAttribute : Attribute, ITestAction
+    {
+        private readonly string reason;
+
+        public UnixOnlyAttribute(string reason)
+        {
+            this.reason = reason;
+        }
+
+        public ActionTargets Targets => ActionTargets.Test;
+
+        public void BeforeTest(ITest test)
+        {
+            if (!MockUnixSupport.IsUnixPlatform())
+            {
+                Assert.Inconclusive(reason);
+            }
+        }
+
+        public void AfterTest(ITest test) { }
+    }
+}

--- a/tests/UnixSpecifics.cs
+++ b/tests/UnixSpecifics.cs
@@ -1,0 +1,7 @@
+﻿namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    internal static class UnixSpecifics
+    {
+        public const string SlashRoot = "Filesystem root is just '/' in Unix";
+    }
+}

--- a/tests/WindowsOnlyAttribute.cs
+++ b/tests/WindowsOnlyAttribute.cs
@@ -1,0 +1,27 @@
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    internal sealed class WindowsOnlyAttribute : Attribute, ITestAction
+    {
+        private readonly string reason;
+
+        public WindowsOnlyAttribute(string reason)
+        {
+            this.reason = reason;
+        }
+
+        public ActionTargets Targets => ActionTargets.Test;
+
+        public void BeforeTest(ITest test)
+        {
+            if (MockUnixSupport.IsUnixPlatform())
+            {
+                Assert.Inconclusive(reason);
+            }
+        }
+
+        public void AfterTest(ITest test) { }
+    }
+}

--- a/tests/WindowsSpecifics.cs
+++ b/tests/WindowsSpecifics.cs
@@ -1,0 +1,13 @@
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    internal static class WindowsSpecifics
+    {
+        public const string Drives = "Drives are a Windows-only concept";
+
+        public const string AccessControlLists = "ACLs are a Windows-only concept";
+
+        public const string UNCPaths = "UNC paths are a Windows-only concept";
+        
+        public const string StrictPathRules = "Windows has stricter path rules than other platforms";
+    }
+}


### PR DESCRIPTION
See issue in System-IO-Abstractions/System.IO.Abstractions#381

Preserves commit history (double entries are due to my doing a git filter-branch on each of the subdirectories in turn and merging the result).

I think it makes sense, now that this is one-project-per-repo, to put this in CoreFX-style src and tests folders. If you disagree and want to keep the original naming for these then shout and I'll redo it (or you can).

Created with:
```
mkdir tmp
cd tmp
git clone https://github.com/System-IO-Abstractions/System.IO.Abstractions src
git clone https://github.com/System-IO-Abstractions/System.IO.Abstractions tests

cd src
git filter-branch --prune-empty --sub-directory System.IO.Abstractions.TestingHelpers

cd ../tests
git filter-branch --prune-empty --sub-directory System.IO.Abstractions.TestingHelpers.Tests

cd ../
git clone https://github.com/<username>/System.IO.Abstractions.TestingHelpers import
cd import

git remote add src ../src
git fetch src
git merge -s ours --no-commit --allow-unrelated-histories src/master
git read-tree --prefix=src -u src/master
git commit -m 'Add System.IO.Abstrations.TestingHelpers'

git remote add tests ../tests
git fetch tests
git merge -s ours --no-commit --allow-unrelated-histories tests/master
git read-tree --prefix=tests -u test/master
git commit -m 'Add System.IO.Abstrations.TestingHelpers.Tests'
```
(Replace the `--prefix=<directory>` if you wish to rewrite the changes into a different directory.)